### PR TITLE
Add supporting infrastructure for Tenttiarkisto

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -87,3 +87,4 @@ env:
   TF_VAR_tikjob_ghost_mail_username: ${{ secrets.TF_VAR_GHOST_MAIL_USERNAME }}
   TF_VAR_tikjob_ghost_mail_password: ${{ secrets.TF_VAR_GHOST_MAIL_PASSWORD }}
   TF_VAR_tikjob_cert_password: ${{ secrets.TF_VAR_TIKJOB_CERT_PASSWORD }}
+  TF_VAR_tenttiarkisto_django_secret_key: ${{ secrets.TF_VAR_TENTTIARKISTO_DJANGO_SECRET_KEY }}

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,18 @@ module "histotik" {
   resource_group_location = module.common.resource_group_location
 }
 
+module "tenttiarkisto" {
+  source                       = "./modules/tenttiarkisto"
+  env_name                     = terraform.workspace
+  postgres_resource_group_name = module.common.resource_group_name
+  resource_group_location      = module.common.resource_group_location
+  postgres_server_name         = module.common.postgres_server_name
+  postgres_server_fqdn         = module.common.postgres_server_fqdn
+  postgres_server_host         = module.common.postgres_server_host
+  postgres_admin_password      = module.common.postgres_admin_password
+  django_secret_key            = var.tenttiarkisto_django_secret_key
+}
+
 module "tikjob_storage" {
   source                  = "./modules/recruiting/storage"
   env_name                = terraform.workspace

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -13,6 +13,7 @@ resource "random_password" "db_password" {
   override_special = "_%@"
 }
 
+# Shared Postgres server
 resource "azurerm_postgresql_server" "tikweb_pg" {
   name                = local.pg_server_name
   location            = azurerm_resource_group.tikweb_rg.location
@@ -38,4 +39,19 @@ resource "azurerm_postgresql_firewall_rule" "tikweb_pg_internal_access" {
   server_name         = azurerm_postgresql_server.tikweb_pg.name
   start_ip_address    = "0.0.0.0"
   end_ip_address      = "0.0.0.0"
+}
+
+# Shared App Service Plan for auxiliary services
+resource "azurerm_app_service_plan" "aux_plan" {
+  name                = "tik-aux-${var.env_name}-plan"
+  location            = azurerm_resource_group.tikweb_rg.location
+  resource_group_name = azurerm_resource_group.tikweb_rg.name
+
+  kind     = "linux"
+  reserved = true # Needs to be true for linux
+
+  sku {
+    tier = "Basic"
+    size = "B1"
+  }
 }

--- a/modules/common/output.tf
+++ b/modules/common/output.tf
@@ -22,3 +22,7 @@ output "postgres_admin_password" {
   value     = azurerm_postgresql_server.tikweb_pg.administrator_login_password
   sensitive = true
 }
+
+output "aux_app_plan_id" {
+  value = azurerm_app_service_plan.aux_plan.id
+}

--- a/modules/tenttiarkisto/main.tf
+++ b/modules/tenttiarkisto/main.tf
@@ -1,0 +1,33 @@
+locals {
+  db_name = "${var.env_name}_tentti_db"
+}
+
+resource "azurerm_resource_group" "tenttiarkisto_rg" {
+  name     = "tenttiarkisto-${var.env_name}-rg"
+  location = var.resource_group_location
+}
+
+resource "azurerm_postgresql_database" "tenttiarkisto_db" {
+  name                = local.db_name
+  resource_group_name = var.postgres_resource_group_name
+  server_name         = var.postgres_server_name
+  charset             = "UTF8"
+  collation           = "fi-FI"
+}
+
+resource "azurerm_storage_account" "tenttiarkisto_storage_account" {
+  name                      = "tenttiarkisto${var.env_name}sa"
+  resource_group_name       = azurerm_resource_group.tenttiarkisto_rg.name
+  location                  = azurerm_resource_group.tenttiarkisto_rg.location
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  allow_blob_public_access  = true
+  enable_https_traffic_only = true
+  min_tls_version           = "TLS1_2"
+}
+
+resource "azurerm_storage_container" "tenttiarkisto_storage_container" {
+  name                  = "exams"
+  storage_account_name  = azurerm_storage_account.tenttiarkisto_storage_account.name
+  container_access_type = "blob"
+}

--- a/modules/tenttiarkisto/variables.tf
+++ b/modules/tenttiarkisto/variables.tf
@@ -1,0 +1,33 @@
+variable "env_name" {
+  type = string
+}
+
+variable "postgres_resource_group_name" {
+  type = string
+}
+
+variable "resource_group_location" {
+  type = string
+}
+
+variable "postgres_server_name" {
+  type = string
+}
+
+variable "postgres_server_fqdn" {
+  type = string
+}
+
+variable "postgres_admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "postgres_server_host" {
+  type = string
+}
+
+variable "django_secret_key" {
+  type      = string
+  sensitive = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -35,3 +35,8 @@ variable "tikjob_cert_password" {
   type      = string
   sensitive = true
 }
+
+variable "tenttiarkisto_django_secret_key" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
Adding database & blob storage for Tenttiarkisto. Will be testing these locally and pushing the App Service implementation locally.

I propose using a shared App Service Plan ([apparently, that's a thing](https://docs.microsoft.com/en-us/azure/app-service/overview-hosting-plans)) for Tenttiarkisto, Varjo-opinto-opas and other similar lower-priority services, and using the same Postgres server for everything. This saves us some costs; while we currently have a lot of budget available, it won't hurt to be a bit conservative, in case we want to expand our usage or Azure decides to reduce the sponsorship amount.

We may want to reconsider the Postgres part. Ideally we'd have per-service users there, but that would require creating a `postgres` Terraform provider that depends on the Postgres server resource, and [that's not perfectly supported as of now](https://github.com/hashicorp/terraform/issues/2430). However, Azure DB servers are quite expensive, so I'll avoid it now if possible.