### PR TITLE
Add ALLOW_ORIGIN for ilmomasiina

### DIFF
--- a/modules/ilmo/main.tf
+++ b/modules/ilmo/main.tf
@@ -70,6 +70,8 @@ resource "azurerm_app_service" "ilmo_backend" {
     MAILGUN_API_KEY = var.mailgun_api_key
     MAILGUN_DOMAIN  = var.mailgun_domain
 
+    ALLOW_ORIGIN = "*"
+
     EMAIL_BASE_URL = "https://tik-ilmo-${var.env_name}-app.azurewebsites.net"
 
     BRANDING_MAIL_FOOTER_TEXT = ""


### PR DESCRIPTION
We'll need this for dev use. In the future we may set up a staging env for Ilmomasiina, at which point we can make the prod CORS more strict.