### PR TITLE
Upgrade Actions to support Node 16

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Install the latest version of Terraform CLI
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
 
       # Initialize Terraform working directory
       - name: Initialize Terraform
@@ -53,11 +53,11 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Install the latest version of Terraform CLI
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
 
       # Initialize Terraform working directory
       - name: Initialize Terraform


### PR DESCRIPTION
This change among others:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/