### PR TITLE
Fixes to TXT records

### DIFF
--- a/modules/dns/prod/main.tf
+++ b/modules/dns/prod/main.tf
@@ -27,25 +27,17 @@ resource "azurerm_dns_mx_record" "root_mx" {
   }
 }
 
-# Google site verification key for tietokilta.fi
-resource "azurerm_dns_txt_record" "root_google_verification" {
+resource "azurerm_dns_txt_record" "root_txt" {
   name                = "@"
   resource_group_name = var.dns_resource_group_name
   zone_name           = var.root_zone_name
   ttl                 = 300
 
+  # Google site verification key
   record {
     value = "google-site-verification=OVm2WzCdpqDTSv0LiDyGGutXT0I8YIlBwuyRHyMJFfw"
   }
-}
-
-# SPF record for tietokilta.fi
-resource "azurerm_dns_txt_record" "root_spf" {
-  name                = "@"
-  resource_group_name = var.dns_resource_group_name
-  zone_name           = var.root_zone_name
-  ttl                 = 300
-
+  # SPF record
   record {
     value = "v=spf1 include:_spf.google.com include:mailgun.org a:tietokilta.fi ~all"
   }

--- a/modules/forum/dns.tf
+++ b/modules/forum/dns.tf
@@ -81,7 +81,7 @@ resource "azurerm_dns_txt_record" "forum_spf" {
   ttl                 = 300
 
   record {
-    value = "v=spf1 mx include:mailgun.org ~all"
+    value = "v=spf1 include:mailgun.org ~all"
   }
 }
 

--- a/modules/mattermost/dns.tf
+++ b/modules/mattermost/dns.tf
@@ -36,7 +36,7 @@ resource "azurerm_dns_txt_record" "mm_spf" {
   ttl                 = 300
 
   record {
-    value = "v=spf1 mx include:mailgun.org ~all"
+    value = "v=spf1 include:mailgun.org ~all"
   }
 }
 

--- a/modules/recruiting/ghost/dns.tf
+++ b/modules/recruiting/ghost/dns.tf
@@ -19,15 +19,19 @@ resource "azurerm_dns_txt_record" "tikjob_asuid" {
   }
 }
 
-# Google site verification key
-resource "azurerm_dns_txt_record" "tikjob_google_verification" {
+resource "azurerm_dns_txt_record" "tikjob_txt" {
   name                = var.subdomain
   resource_group_name = var.dns_resource_group_name
   zone_name           = var.root_zone_name
   ttl                 = 300
 
+  # Google site verification key
   record {
     value = "google-site-verification=CQLRUnnxEnLtINJtF6cyJJH3YQSA8dxD6ap3qmFma5M"
+  }
+  # SPF record for Mailgun
+  record {
+    value = "v=spf1 include:mailgun.org ~all"
   }
 }
 
@@ -54,18 +58,6 @@ resource "azurerm_dns_mx_record" "tikjob_mx" {
   record {
     preference = 10
     exchange   = "mxb.eu.mailgun.org"
-  }
-}
-
-# SPF record for Mailgun
-resource "azurerm_dns_txt_record" "tikjob_spf" {
-  name                = var.subdomain
-  resource_group_name = var.dns_resource_group_name
-  zone_name           = var.root_zone_name
-  ttl                 = 300
-
-  record {
-    value = "v=spf1 mx include:mailgun.org ~all"
   }
 }
 


### PR DESCRIPTION
Removed unnecessary `mx` from some SPFs and ensured only one `txt_record` per name.