### PR TITLE
Update resources for Azure provider v3

### DIFF
--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -42,16 +42,11 @@ resource "azurerm_postgresql_firewall_rule" "tikweb_pg_internal_access" {
 }
 
 # Shared App Service Plan for auxiliary services
-resource "azurerm_app_service_plan" "aux_plan" {
+resource "azurerm_service_plan" "aux_plan" {
   name                = "tik-aux-${var.env_name}-plan"
   location            = azurerm_resource_group.tikweb_rg.location
   resource_group_name = azurerm_resource_group.tikweb_rg.name
 
-  kind     = "linux"
-  reserved = true # Needs to be true for linux
-
-  sku {
-    tier = "Basic"
-    size = "B1"
-  }
+  os_type  = "Linux"
+  sku_name = "B1"
 }

--- a/modules/common/output.tf
+++ b/modules/common/output.tf
@@ -20,5 +20,5 @@ output "postgres_admin_password" {
 }
 
 output "aux_app_plan_id" {
-  value = azurerm_app_service_plan.aux_plan.id
+  value = azurerm_service_plan.aux_plan.id
 }

--- a/modules/recruiting/ghost/dns.tf
+++ b/modules/recruiting/ghost/dns.tf
@@ -15,7 +15,7 @@ resource "azurerm_dns_txt_record" "tikjob_asuid" {
   ttl                 = 300
 
   record {
-    value = azurerm_app_service.tikjob_ghost.custom_domain_verification_id
+    value = azurerm_linux_web_app.tikjob_ghost.custom_domain_verification_id
   }
 }
 


### PR DESCRIPTION
**NOTE: I've `terraform import`'ed all these changes. Please don't try to apply anything before this is merged.**

Read through https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide and updated everything that seemed relevant.

This also adds some changes to defaults, like TLS v1.2 requiring. Those all seemed fine to me.