### PR TITLE
fix: Add oldweb to Azure (2nd try)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -381,6 +381,9 @@ module "oldweb" {
   postgres_server_id      = module.common.postgres_server_id
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "old"
+  tikweb_app_plan_id      = module.common.tikweb_app_plan_id
+  tikweb_rg_location      = module.common.resource_group_location
+  tikweb_rg_name          = module.common.resource_group_name
   location                = local.resource_group_location
 }
 

--- a/modules/oldweb/main.tf
+++ b/modules/oldweb/main.tf
@@ -38,4 +38,63 @@ resource "azurerm_container_registry" "acr" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   sku                 = "Basic"
+  admin_enabled       = false
+}
+
+# Create actual application
+resource "azurerm_linux_web_app" "oldweb_backend" {
+  name                = "tik-oldweb-${var.env_name}-app"
+  location            = var.tikweb_rg_location
+  resource_group_name = var.tikweb_rg_name
+  service_plan_id     = var.tikweb_app_plan_id
+
+  https_only = true
+
+  site_config {
+    ftps_state = "Disabled"
+    always_on  = true
+
+    application_stack {
+      docker_registry_url = "https://${azurerm_container_registry.acr.login_server}"
+      docker_image_name   = "oldweb:latest"
+    }
+  }
+
+  logs {
+    http_logs {
+      file_system {
+        retention_in_days = 7
+        retention_in_mb   = 100
+      }
+    }
+  }
+
+  # Mount the Azure File Share for images and other attachments
+  storage_account {
+    name         = "oldweb-persistent-storage"
+    account_name = azurerm_storage_account.storage_account.name
+    access_key   = azurerm_storage_account.storage_account.primary_access_key
+    mount_path   = "/app/public/page_attachments"
+    share_name   = azurerm_storage_share.file_share.name
+    type         = "AzureFiles"
+  }
+
+  # Configuration for oldweb
+  app_settings = {
+    WEBSITES_PORT = 3000
+    PORT          = 3000
+
+    DB_USERNAME = "tietokilta"
+    DB_PASSWORD = var.postgres_admin_password
+    DB_HOST     = var.postgres_server_fqdn
+    DB_DATABASE = local.db_name
+    DB_PORT     = 5432
+
+  }
+
+  lifecycle {
+    ignore_changes = [
+      site_config.0.application_stack, # deployments are made outside of Terraform
+    ]
+  }
 }

--- a/modules/oldweb/outputs.tf
+++ b/modules/oldweb/outputs.tf
@@ -1,0 +1,7 @@
+output "fqdn" {
+  value = local.fqdn
+}
+
+output "web_app_id" {
+  value = azurerm_linux_web_app.oldweb_backend.id
+}

--- a/modules/oldweb/variables.tf
+++ b/modules/oldweb/variables.tf
@@ -31,6 +31,18 @@ variable "subdomain" {
   type = string
 }
 
+variable "tikweb_app_plan_id" {
+  type = string
+}
+
+variable "tikweb_rg_name" {
+  type = string
+}
+
+variable "tikweb_rg_location" {
+  type = string
+}
+
 variable "location" {
   description = "Azure location"
   type        = string


### PR DESCRIPTION
Instead of creating new permissions, ACR now creates admin account that can be used for pulling images