### PR TITLE
feat: Update old.tietokilta.fi DNS to point to Azure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -379,8 +379,10 @@ module "oldweb" {
   postgres_server_fqdn    = module.common.postgres_server_fqdn
   postgres_admin_password = module.common.postgres_admin_password
   postgres_server_id      = module.common.postgres_server_id
+  dns_resource_group_name = module.dns_prod.resource_group_name
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "old"
+  acme_account_key        = module.common.acme_account_key
   tikweb_app_plan_id      = module.common.tikweb_app_plan_id
   tikweb_rg_location      = module.common.resource_group_location
   tikweb_rg_name          = module.common.resource_group_name

--- a/modules/dns/root/main.tf
+++ b/modules/dns/root/main.tf
@@ -7,13 +7,3 @@ resource "azurerm_dns_zone" "root_zone" {
   name                = var.zone_name
   resource_group_name = azurerm_resource_group.dns_rg.name
 }
-
-
-# record for old website
-resource "azurerm_dns_a_record" "old_a" {
-  name                = "old"
-  resource_group_name = azurerm_resource_group.dns_rg.name
-  zone_name           = azurerm_dns_zone.root_zone.name
-  ttl                 = 300
-  records             = ["130.233.48.30"]
-}

--- a/modules/oldweb/dns.tf
+++ b/modules/oldweb/dns.tf
@@ -1,0 +1,20 @@
+# A record for the web app
+resource "azurerm_dns_a_record" "oldweb_a" {
+  name                = var.subdomain
+  resource_group_name = var.dns_resource_group_name
+  zone_name           = var.root_zone_name
+  ttl                 = 300
+  records             = data.dns_a_record_set.oldweb_dns_fetch.addrs
+}
+
+# Azure verification key
+resource "azurerm_dns_txt_record" "oldweb_asuid" {
+  name                = "asuid.${var.subdomain}"
+  resource_group_name = var.dns_resource_group_name
+  zone_name           = var.root_zone_name
+  ttl                 = 300
+
+  record {
+    value = azurerm_linux_web_app.oldweb_backend.custom_domain_verification_id
+  }
+}

--- a/modules/oldweb/variables.tf
+++ b/modules/oldweb/variables.tf
@@ -22,6 +22,9 @@ variable "postgres_server_id" {
   type = string
 }
 
+variable "dns_resource_group_name" {
+  type = string
+}
 
 variable "root_zone_name" {
   type = string
@@ -40,6 +43,10 @@ variable "tikweb_rg_name" {
 }
 
 variable "tikweb_rg_location" {
+  type = string
+}
+
+variable "acme_account_key" {
   type = string
 }
 


### PR DESCRIPTION
Removes old DNS record and poins `old.tietokilta.fi` to new version running on Azure