### PR TITLE
feat: add juhlavuosi.fi DNS root zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,12 @@ module "dns_m0" {
   resource_group_location = local.resource_group_location
   zone_name               = "muistinnollaus.fi"
 }
+module "dns_juvusivu" {
+  source                  = "./modules/dns/root"
+  env_name                = "prod"
+  resource_group_location = local.resource_group_location
+  zone_name               = "juhlavuosi.fi"
+}
 module "tenttiarkisto_dns_zone" {
   source                  = "./modules/dns/root"
   env_name                = "prod"


### PR DESCRIPTION
- Add DNS root zone for juhlavuosi.fi, so that the domain can later be assigned to the App Service