### PR TITLE
fix: use unique env_name for juhlavuosi DNS root zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ module "dns_m0" {
 }
 module "dns_juvusivu" {
   source                  = "./modules/dns/root"
-  env_name                = "prod"
+  env_name                = "juvu"
   resource_group_location = local.resource_group_location
   zone_name               = "juhlavuosi.fi"
 }


### PR DESCRIPTION
Apparently `env_name` must be unique, as resource group is generated based on it

See [failed run](https://github.com/Tietokilta/infra/actions/runs/17431309537/job/49490164395)