### PR TITLE
feat: add juhlavuosi.fi for actual juvu page

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ module "dns_m0" {
 }
 module "dns_juvusivu" {
   source                  = "./modules/dns/root"
-  env_name                = "prod"
+  env_name                = "juvu"
   resource_group_location = local.resource_group_location
   zone_name               = "juhlavuosi.fi"
 }

--- a/main.tf
+++ b/main.tf
@@ -513,6 +513,9 @@ module "juvusivu" {
   postgres_server_fqdn                 = module.common.postgres_server_fqdn
   postgres_admin_password              = module.common.postgres_admin_password
   postgres_server_id                   = module.common.postgres_server_id
+  acme_account_key                     = module.common.acme_account_key
+  dns_resource_group_name              = module.dns_juvusivu.resource_group_name
+  root_zone_name                       = module.dns_juvusivu.root_zone_name
 }
 
 module "status" {

--- a/modules/juvusivu/main.tf
+++ b/modules/juvusivu/main.tf
@@ -89,3 +89,18 @@ resource "azurerm_linux_web_app" "juvusivu" {
     DB_PORT     = 5432
   }
 }
+
+module "juvusivu_hostname" {
+  source = "../app_service_hostname"
+
+  subdomain                       = "@"
+  dns_resource_group_name         = var.dns_resource_group_name
+  custom_domain_verification_id   = azurerm_linux_web_app.juvusivu.custom_domain_verification_id
+  app_service_name                = azurerm_linux_web_app.juvusivu.name
+  app_service_resource_group_name = var.app_service_plan_resource_group_name
+  app_service_location            = var.app_service_plan_location
+  app_service_default_hostname    = azurerm_linux_web_app.juvusivu.default_hostname
+  acme_account_key                = var.acme_account_key
+  certificate_name                = "juvusivu-cert"
+  root_zone_name                  = var.root_zone_name
+}

--- a/modules/juvusivu/variables.tf
+++ b/modules/juvusivu/variables.tf
@@ -31,3 +31,17 @@ variable "postgres_admin_password" {
 variable "postgres_server_id" {
   type = string
 }
+
+// DNS
+variable "acme_account_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "dns_resource_group_name" {
+  type = string
+}
+
+variable "root_zone_name" {
+  type = string
+}


### PR DESCRIPTION
Use juhlavuosi.fi domain for the actual juhlavuosi page.

*Before merging this, #134 should be merged and nameservers for the domain should be updated*