### PR TITLE
chore: clean up ilmo config after 3.0.0-alpha.10

### DIFF
--- a/modules/ilmo/main.tf
+++ b/modules/ilmo/main.tf
@@ -62,11 +62,6 @@ resource "azurerm_linux_web_app" "ilmo_backend" {
 
     # Paths from tikweb-web
     BASE_URL = var.website_url
-    # TODO: remove _URLs once Ilmomasiina v3.0.0-alpha.8 deployed
-    EVENT_DETAILS_URL    = "${var.website_url}/{lang}/events/{slug}"
-    EDIT_SIGNUP_URL      = "${var.website_url}/{lang}/signups/{id}/{editToken}"
-    COMPLETE_PAYMENT_URL = "${var.website_url}/{lang}/payment/{id}/{editToken}"
-    ADMIN_URL            = "https://${module.app_service_hostname.fqdn}/admin"
     FRONTENDS = jsonencode(merge({
       "default" = {
         "eventDetailsUrl"    = "${var.website_url}/{lang}/events/{slug}"

--- a/modules/ilmo_staging/main.tf
+++ b/modules/ilmo_staging/main.tf
@@ -59,10 +59,14 @@ resource "azurerm_linux_web_app" "ilmo_backend" {
 
     # Paths from tikweb-web
     BASE_URL             = var.website_url
-    EVENT_DETAILS_URL    = "${var.website_url}/{lang}/events/{slug}"
-    EDIT_SIGNUP_URL      = "${var.website_url}/{lang}/signups/{id}/{editToken}"
-    COMPLETE_PAYMENT_URL = "${var.website_url}/{lang}/payment/{id}/{editToken}"
-    ADMIN_URL            = "https://tik-ilmo-${var.environment}-app.azurewebsites.net/admin"
+    FRONTENDS = jsonencode(merge({
+      "default" = {
+        "eventDetailsUrl"    = "${var.website_url}/{lang}/events/{slug}"
+        "editSignupUrl"      = "${var.website_url}/{lang}/signups/{id}/{editToken}"
+        "completePaymentUrl" = "${var.website_url}/{lang}/payment/{id}/{editToken}"
+        "adminUrl"           = "https://${module.app_service_hostname.fqdn}/admin"
+      }
+    }))
 
     ICAL_UID_DOMAIN = "tietokilta.fi"
 

--- a/modules/ilmo_staging/main.tf
+++ b/modules/ilmo_staging/main.tf
@@ -58,13 +58,13 @@ resource "azurerm_linux_web_app" "ilmo_backend" {
     ALLOW_ORIGIN = "*"
 
     # Paths from tikweb-web
-    BASE_URL             = var.website_url
+    BASE_URL = var.website_url
     FRONTENDS = jsonencode(merge({
       "default" = {
         "eventDetailsUrl"    = "${var.website_url}/{lang}/events/{slug}"
         "editSignupUrl"      = "${var.website_url}/{lang}/signups/{id}/{editToken}"
         "completePaymentUrl" = "${var.website_url}/{lang}/payment/{id}/{editToken}"
-        "adminUrl"           = "https://${module.app_service_hostname.fqdn}/admin"
+        "adminUrl"           = "https://tik-ilmo-${var.environment}-app.azurewebsites.net/admin"
       }
     }))
 

--- a/modules/ilmo_staging/variables.tf
+++ b/modules/ilmo_staging/variables.tf
@@ -54,3 +54,13 @@ variable "stripe_webhook_secret" {
   type      = string
   sensitive = true
 }
+
+variable "extra_frontends" {
+  type = map(object({
+    eventDetailsUrl    = optional(string)
+    editSignupUrl      = optional(string)
+    completePaymentUrl = optional(string)
+    adminUrl           = optional(string)
+  }))
+  default = {}
+}


### PR DESCRIPTION
- Remove no longer used variables
- Sync `ilmo_staging` config variables. `FRONTENDS` will be a no-op and staging will use the default URLs until it's rebuilt for something again, but it doesn't hurt to already have it.