### PR TITLE
feat: Enable PgBouncer to tackle zombie connections

### DIFF
--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -43,6 +43,43 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "tikweb_pg_new_firew
   start_ip_address = "0.0.0.0"
   end_ip_address   = "0.0.0.0"
 }
+
+# Built-in PgBouncer (listens on port 6432). Multiplexes client connections
+# onto the server's small max_connections pool so idle/zombie client sessions
+# don't exhaust it.
+resource "azurerm_postgresql_flexible_server_configuration" "pgbouncer_enabled" {
+  name      = "pgbouncer.enabled"
+  server_id = azurerm_postgresql_flexible_server.tikweb_pg_new.id
+  value     = "true"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "pgbouncer_pool_mode" {
+  name      = "pgbouncer.pool_mode"
+  server_id = azurerm_postgresql_flexible_server.tikweb_pg_new.id
+  value     = "TRANSACTION"
+}
+
+# B_Standard_B1ms has max_connections=50. With ~8 service DBs, keep
+# default_pool_size small so total server-side conns stay under the cap.
+resource "azurerm_postgresql_flexible_server_configuration" "pgbouncer_default_pool_size" {
+  name      = "pgbouncer.default_pool_size"
+  server_id = azurerm_postgresql_flexible_server.tikweb_pg_new.id
+  value     = "5"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "pgbouncer_max_client_conn" {
+  name      = "pgbouncer.max_client_conn"
+  server_id = azurerm_postgresql_flexible_server.tikweb_pg_new.id
+  value     = "200"
+}
+
+# Accept startup params that ORMs (Sequelize, Django) routinely set but that
+# pgbouncer can't forward in transaction mode.
+resource "azurerm_postgresql_flexible_server_configuration" "pgbouncer_ignore_startup_parameters" {
+  name      = "pgbouncer.ignore_startup_parameters"
+  server_id = azurerm_postgresql_flexible_server.tikweb_pg_new.id
+  value     = "extra_float_digits,search_path"
+}
 # Shared App Service Plan
 resource "azurerm_service_plan" "tikweb_plan" {
   name                = "tik-${var.env_name}-app-service-plan"

--- a/modules/common/output.tf
+++ b/modules/common/output.tf
@@ -22,6 +22,14 @@ output "postgres_server_id" {
 output "postgres_server_fqdn" {
   value = azurerm_postgresql_flexible_server.tikweb_pg_new.fqdn
 }
+
+output "postgres_server_port" {
+  value = 5432
+}
+
+output "postgres_pgbouncer_port" {
+  value = 6432
+}
 output "postgres_server_name" {
   value = azurerm_postgresql_flexible_server.tikweb_pg_new.name
 }

--- a/modules/ilmo/main.tf
+++ b/modules/ilmo/main.tf
@@ -44,6 +44,7 @@ resource "azurerm_linux_web_app" "ilmo_backend" {
 
     DB_DIALECT  = "postgres"
     DB_HOST     = var.postgres_server_fqdn
+    DB_PORT     = 6432
     DB_SSL      = true
     DB_DATABASE = module.service_database.db_name
     DB_USER     = module.service_database.db_user

--- a/modules/ilmo_staging/main.tf
+++ b/modules/ilmo_staging/main.tf
@@ -43,6 +43,7 @@ resource "azurerm_linux_web_app" "ilmo_backend" {
 
     DB_DIALECT  = "postgres"
     DB_HOST     = var.postgres_server_fqdn
+    DB_PORT     = 6432
     DB_SSL      = true
     DB_DATABASE = module.service_database.db_name
     DB_USER     = module.service_database.db_user

--- a/modules/juvusivu/main.tf
+++ b/modules/juvusivu/main.tf
@@ -91,7 +91,7 @@ resource "azurerm_linux_web_app" "juvusivu" {
     DB_PASSWORD = module.service_database.db_password
     DB_HOST     = var.postgres_server_fqdn
     DB_NAME     = module.service_database.db_name
-    DB_PORT     = 5432
+    DB_PORT     = 6432
 
     PRIMARY_DOMAIN = var.root_zone_name // For m0 redirect
   }

--- a/modules/oldweb/main.tf
+++ b/modules/oldweb/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_linux_web_app" "oldweb_backend" {
     DB_PASSWORD = module.service_database.db_password
     DB_HOST     = var.postgres_server_fqdn
     DB_DATABASE = module.service_database.db_name
-    DB_PORT     = 5432
+    DB_PORT     = 6432
 
   }
 }

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_linux_web_app" "registry" {
     BODY_SIZE_LIMIT = "5M"
 
     DATABASE_URL = format(
-      "postgres://%s:%s@%s:5432/%s",
+      "postgres://%s:%s@%s:6432/%s",
       module.service_database.db_user,
       urlencode(module.service_database.db_password),
       var.postgres_server_fqdn,

--- a/modules/running-challenge/main.tf
+++ b/modules/running-challenge/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_linux_web_app" "running_challenge" {
     CLIENT_SECRET = var.client_secret
     REFRESH_TOKEN = var.refresh_token
     PGHOST        = var.postgres_server_fqdn
-    PGPORT        = 5432
+    PGPORT        = 6432
     PGDATABASE    = module.service_database.db_name
     PGUSER        = module.service_database.db_user
     PGPASSWORD    = module.service_database.db_password

--- a/modules/tenttiarkisto/main.tf
+++ b/modules/tenttiarkisto/main.tf
@@ -79,6 +79,7 @@ resource "azurerm_linux_web_app" "tenttiarkisto" {
     DB_USER     = module.service_database.db_user
     DB_PASSWORD = module.service_database.db_password
     DB_HOST     = var.postgres_server_fqdn
+    DB_PORT     = 6432
 
     SECRET_KEY = var.django_secret_key
 


### PR DESCRIPTION
## Notes:
PgBouncer enabled for the following services:
- ilmomasiina
- juvusivu
- oldweb
- registry
- running-challenge
- tenttiarkisto

PgBouncer not enabled for the following services:
- ISOpistekortti, hard-coded db port in db.js
- vaultwarden, uses postgres admin credentials
- tikpannu-backup: pg_dump requires session pooling, can't work through azure pgbouncer