### PR TITLE
feat: add Cloudflare DNS (dual-stack with Azure)

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,23 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.19.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:DfwnA214pLOZnVHnUzCqrDYb+mKbZjcfgYVYtDfMP/w=",
+    "zh:1946c61d0aeffd3fed14cc55581f125d798fed14b0c1f9f765fecf46dbf4baff",
+    "zh:2b8028e59b93aa6388a74721902d15b2742460353809453dbee13be55f68dd31",
+    "zh:4e21ff650e5fc6ab3e592618dcddc02f35ab8a70e146a77de59a124030a1abd9",
+    "zh:75afe38d6d009dad42229a7fa22d4a05ebd9815050deb523d50a2b6deb6a0156",
+    "zh:867879ebca16e8eda4515367bac9cefd1ede4c06e4c62260efb32cadf866c34f",
+    "zh:a978dd6fa8d1a1b90f17c56ec7e1259e4e569ca0a851724d7c0f0e9c5b1016c0",
+    "zh:db0db1f9c19fd9382908e413cedc62b18b67dfe09807ba101df093a9bd16da01",
+    "zh:e41d361df586e76fe7ac8c27424949d2d9bc11903de0f9d52f2d0f9d1844eed8",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
 provider "registry.terraform.io/cyrilgdn/postgresql" {
   version     = "1.26.0"
   constraints = ">= 1.13.0"

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~>3.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~>5.0"
+    }
     dns = {
       source  = "hashicorp/dns"
       version = "~>3.4"
@@ -54,6 +58,10 @@ provider "acme" {
 
 provider "mailgun" {
   api_key = module.keyvault.secrets["mailgun-terraform-api-key"]
+}
+
+provider "cloudflare" {
+  api_token = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 provider "postgresql" {
@@ -117,9 +125,27 @@ module "keyvault" {
     "registry-stripe-api-key",
     "registry-stripe-webhook-secret",
     "mailgun-terraform-api-key",
+    "cloudflare-api-token",
     "running-challenge-client-id",
     "running-challenge-client-secret",
     "running-challenge-refresh-token"
+  ]
+}
+
+module "cloudflare" {
+  source = "./modules/cloudflare"
+
+  zone_name              = "tietokilta.fi"
+  github_challenge_value = module.keyvault.secrets["github-challenge-value"]
+  # Hardcoded to avoid circular dependency with modules that consume cloudflare.zone_id
+  dmarc_report_domains = [
+    "list.tietokilta.fi",
+    "list.tietokila.fi",
+    "rekry.tietokilta.fi",
+    "ilmo.tietokilta.fi",
+    "laskutus.tietokilta.fi",
+    "vaalit.tietokilta.fi",
+    "rekisteri.tietokilta.fi",
   ]
 }
 
@@ -171,6 +197,7 @@ module "mailman" {
   dns_resource_group_name = module.dns_prod.resource_group_name
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "list"
+  cloudflare_zone_id      = module.cloudflare.zone_id
 
   dkim_selector = "mta"
   dkim_key      = "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJN6WyS7YQcOKO4MKsSbrYfjL8hh24ot/0uQysHte3eqscbbwCFVlgmsg3423by3e20ZSBMhRXdtIkYdgn8wkfPyZlHVEOvOJBCR+tKqtexxQEbkk8LqmEzVggNZoLLX06wYNqt2Nxl++dlvUuB4IxmPPGQed3Xr7HBT8OZmKJYQIDAQAB"
@@ -266,6 +293,8 @@ module "web" {
   mailgun_api_key              = module.keyvault.secrets["mailgun-api-key"]
   mailgun_domain               = module.keyvault.secrets["mailgun-domain"]
   mailgun_url                  = module.keyvault.secrets["mailgun-url"]
+  cloudflare_zone_id           = module.cloudflare.zone_id
+  cloudflare_api_token         = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 resource "azurerm_key_vault_secret" "cms_password" {
@@ -299,6 +328,8 @@ module "ilmo" {
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "ilmo"
   acme_account_key        = module.common.acme_account_key
+  cloudflare_zone_id      = module.cloudflare.zone_id
+  cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "ilmo_staging" {
@@ -326,6 +357,7 @@ module "histotik" {
   dns_resource_group_name = module.dns_prod.resource_group_name
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "histotik"
+  cloudflare_zone_id      = module.cloudflare.zone_id
 }
 
 module "tenttiarkisto" {
@@ -384,6 +416,8 @@ module "tikjob_app" {
   dns_resource_group_name = module.dns_prod.resource_group_name
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "rekry"
+  cloudflare_zone_id      = module.cloudflare.zone_id
+  cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "tikjob_tg_bot" {
@@ -407,6 +441,7 @@ module "discourse" {
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "vaalit"
   discourse_ip            = "46.62.222.17"
+  cloudflare_zone_id      = module.cloudflare.zone_id
 
   dkim_selector = "mta"
   dkim_key      = "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCzppfPnLHshnORT2P0C3OBuo80OCsCOpLHQS2txfRq2k+y+P4rocFy4z1H0397Ijy6wKM+VI3qOnc8RzVkaZib8+p08jBf/O/hxTwTkuMrotdIo2zrfBq+T1AaYMj4zNJnPt10+vLptpEA6m0XIWsu7wTRE6WfqHjlHj7CwkhTzwIDAQAB"
@@ -419,6 +454,7 @@ module "tikpannu" {
   root_zone_name          = module.dns_prod.root_zone_name
   subdomain               = "pannu"
   tikpannu_ip             = "46.62.222.17"
+  cloudflare_zone_id      = module.cloudflare.zone_id
 }
 
 module "invoicing" {
@@ -433,6 +469,8 @@ module "invoicing" {
   resource_group_name     = module.common.resource_group_name
   app_service_plan_id     = module.common.tikweb_app_plan_id
   acme_account_key        = module.common.acme_account_key
+  cloudflare_zone_id      = module.cloudflare.zone_id
+  cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "registry" {
@@ -450,6 +488,8 @@ module "registry" {
   mailgun_api_key         = module.keyvault.secrets["registry-mailgun-api-key"]
   stripe_api_key          = module.keyvault.secrets["registry-stripe-api-key"]
   stripe_webhook_secret   = module.keyvault.secrets["registry-stripe-webhook-secret"]
+  cloudflare_zone_id      = module.cloudflare.zone_id
+  cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "oldweb" {
@@ -466,6 +506,8 @@ module "oldweb" {
   tikweb_rg_name          = module.common.resource_group_name
   location                = local.resource_group_location
   ghcr_token              = module.keyvault.secrets["oldweb-ghcr-access-token"]
+  cloudflare_zone_id      = module.cloudflare.zone_id
+  cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "vaultwarden" {
@@ -488,6 +530,8 @@ module "vaultwarden" {
   acme_account_key                     = module.common.acme_account_key
   root_zone_name                       = module.dns_prod.root_zone_name
   subdomain                            = "vault"
+  cloudflare_zone_id                   = module.cloudflare.zone_id
+  cloudflare_api_token                 = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "github-ci-roles" {
@@ -565,6 +609,8 @@ module "status" {
   telegram_token                       = module.keyvault.secrets["status-telegram-token"]
   telegram_channel_id                  = "-1003648545192"
   subdomain                            = "status"
+  cloudflare_zone_id                   = module.cloudflare.zone_id
+  cloudflare_api_token                 = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "running_challenge" {
@@ -582,6 +628,8 @@ module "running_challenge" {
   client_secret           = module.keyvault.secrets["running-challenge-client-secret"]
   refresh_token           = module.keyvault.secrets["running-challenge-refresh-token"]
   club_id                 = "1997937"
+  cloudflare_zone_id      = module.cloudflare.zone_id
+  cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "isopistekortti" {
@@ -596,4 +644,6 @@ module "isopistekortti" {
   root_zone_name          = module.dns_prod.root_zone_name
   dns_resource_group_name = module.dns_prod.resource_group_name
   acme_account_key        = module.common.acme_account_key
+  cloudflare_zone_id      = module.cloudflare.zone_id
+  cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }

--- a/modules/app_service_hostname/main.tf
+++ b/modules/app_service_hostname/main.tf
@@ -3,6 +3,9 @@ terraform {
     acme = {
       source = "vancluever/acme"
     }
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
   }
 }
 
@@ -10,13 +13,55 @@ locals {
   fqdn           = var.subdomain == "@" ? var.root_zone_name : "${var.subdomain}.${var.root_zone_name}"
   asuid_domain   = var.subdomain == "@" ? "" : ".${var.subdomain}"
   is_root_domain = var.subdomain == "@"
+  use_cloudflare = var.cloudflare_zone_id != ""
 }
 
 data "dns_a_record_set" "app_dns_fetch" {
   host = var.app_service_default_hostname
 }
 
-# Root/subdomain records
+# Cloudflare DNS records (only when cloudflare_zone_id is provided)
+resource "cloudflare_dns_record" "app_a_record" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "A"
+  content = data.dns_a_record_set.app_dns_fetch.addrs[0]
+  proxied = var.proxied
+  ttl     = var.proxied ? 1 : 300
+}
+
+# asuid TXT required by Azure App Service for hostname binding verification
+resource "cloudflare_dns_record" "app_asuid_record" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "asuid${local.asuid_domain}"
+  type    = "TXT"
+  content = var.custom_domain_verification_id
+  ttl     = 300
+}
+
+# WWW Cloudflare records (only for root domains using Cloudflare)
+resource "cloudflare_dns_record" "www_cname" {
+  count   = local.is_root_domain && local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "www"
+  type    = "CNAME"
+  content = local.fqdn
+  proxied = var.proxied
+  ttl     = var.proxied ? 1 : 300
+}
+
+resource "cloudflare_dns_record" "www_asuid_record" {
+  count   = local.is_root_domain && local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "asuid.www"
+  type    = "TXT"
+  content = var.custom_domain_verification_id
+  ttl     = 300
+}
+
+# Azure DNS records (kept as-is; non-authoritative once Cloudflare NS are active)
 resource "azurerm_dns_a_record" "app_a_record" {
   name                = var.subdomain
   resource_group_name = var.dns_resource_group_name
@@ -42,12 +87,14 @@ resource "azurerm_app_service_custom_hostname_binding" "app_hostname_binding" {
   resource_group_name = var.app_service_resource_group_name
 
   depends_on = [
+    cloudflare_dns_record.app_a_record,
+    cloudflare_dns_record.app_asuid_record,
     azurerm_dns_a_record.app_a_record,
-    azurerm_dns_txt_record.app_asuid_record
+    azurerm_dns_txt_record.app_asuid_record,
   ]
 }
 
-# WWW records (only for root domains)
+# WWW Azure DNS records (only for root domains)
 resource "azurerm_dns_cname_record" "www_cname" {
   count               = local.is_root_domain ? 1 : 0
   name                = "www"
@@ -76,8 +123,10 @@ resource "azurerm_app_service_custom_hostname_binding" "www_hostname_binding" {
   resource_group_name = var.app_service_resource_group_name
 
   depends_on = [
+    cloudflare_dns_record.www_cname,
+    cloudflare_dns_record.www_asuid_record,
     azurerm_dns_cname_record.www_cname,
-    azurerm_dns_txt_record.www_asuid_record
+    azurerm_dns_txt_record.www_asuid_record,
   ]
 }
 
@@ -95,8 +144,10 @@ resource "acme_certificate" "app_acme_cert" {
   certificate_p12_password  = random_password.app_cert_password.result
 
   dns_challenge {
-    provider = "azuredns"
-    config = {
+    provider = local.use_cloudflare ? "cloudflare" : "azuredns"
+    config = local.use_cloudflare ? {
+      CF_DNS_API_TOKEN = var.cloudflare_api_token
+      } : {
       AZURE_RESOURCE_GROUP = var.dns_resource_group_name
       AZURE_ZONE_NAME      = var.root_zone_name
     }

--- a/modules/app_service_hostname/variables.tf
+++ b/modules/app_service_hostname/variables.tf
@@ -49,3 +49,22 @@ variable "certificate_name" {
   type        = string
   description = "The name of the certificate resource."
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "The Cloudflare zone ID. When set, DNS records are created in Cloudflare and ACME challenge uses CF_DNS_API_TOKEN. Leave empty for zones not managed by Cloudflare (falls back to Azure DNS ACME)."
+  default     = ""
+}
+
+variable "proxied" {
+  type        = bool
+  description = "Whether to enable Cloudflare proxy (orange cloud) for the A record. Enable only for the main web app."
+  default     = false
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge. Required when cloudflare_zone_id is set."
+  sensitive   = true
+  default     = ""
+}

--- a/modules/cloudflare/main.tf
+++ b/modules/cloudflare/main.tf
@@ -1,0 +1,213 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Requires the zone to be added to the Cloudflare account manually first,
+# then NS records updated at the registrar to point to Cloudflare.
+data "cloudflare_zone" "zone" {
+  filter = {
+    name = var.zone_name
+  }
+}
+
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = data.cloudflare_zone.zone.id
+  setting_id = "ssl"
+  value      = "strict"
+}
+
+resource "cloudflare_zone_setting" "always_use_https" {
+  zone_id    = data.cloudflare_zone.zone.id
+  setting_id = "always_use_https"
+  value      = "on"
+}
+
+resource "cloudflare_zone_setting" "min_tls_version" {
+  zone_id    = data.cloudflare_zone.zone.id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "automatic_https_rewrites" {
+  zone_id    = data.cloudflare_zone.zone.id
+  setting_id = "automatic_https_rewrites"
+  value      = "on"
+}
+
+resource "cloudflare_zone_setting" "opportunistic_encryption" {
+  zone_id    = data.cloudflare_zone.zone.id
+  setting_id = "opportunistic_encryption"
+  value      = "on"
+}
+
+resource "cloudflare_zone_setting" "http3" {
+  zone_id    = data.cloudflare_zone.zone.id
+  setting_id = "http3"
+  value      = "on"
+}
+
+# Cache Next.js static assets for one year (filenames include content hashes)
+resource "cloudflare_ruleset" "cache_rules" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "tikweb cache rules"
+  kind    = "zone"
+  phase   = "http_request_cache_settings"
+
+  rules = [{
+    action      = "set_cache_settings"
+    description = "Cache Next.js static assets for 1 year"
+    enabled     = true
+    expression  = "(http.request.uri.path matches \"^/_next/static/\")"
+    action_parameters = {
+      cache = true
+      edge_ttl = {
+        mode    = "override_origin"
+        default = 31536000 # 1 year
+        status_code_ttl = [{
+          status_code = 200
+          value       = 31536000
+        }]
+      }
+      browser_ttl = {
+        mode    = "override_origin"
+        default = 31536000
+      }
+    }
+  }]
+}
+
+# Root domain MX records (Google Workspace)
+resource "cloudflare_dns_record" "mx_aspmx" {
+  zone_id  = data.cloudflare_zone.zone.id
+  name     = "@"
+  type     = "MX"
+  content  = "aspmx.l.google.com"
+  priority = 0
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "mx_alt1_aspmx" {
+  zone_id  = data.cloudflare_zone.zone.id
+  name     = "@"
+  type     = "MX"
+  content  = "alt1.aspmx.l.google.com"
+  priority = 5
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "mx_alt3_aspmx" {
+  zone_id  = data.cloudflare_zone.zone.id
+  name     = "@"
+  type     = "MX"
+  content  = "alt3.aspmx.l.google.com"
+  priority = 10
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "mx_tietokilta" {
+  zone_id  = data.cloudflare_zone.zone.id
+  name     = "@"
+  type     = "MX"
+  content  = "tietokilta.fi"
+  priority = 20
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "mx_mail_cs_hut" {
+  zone_id  = data.cloudflare_zone.zone.id
+  name     = "@"
+  type     = "MX"
+  content  = "mail.cs.hut.fi"
+  priority = 21
+  ttl      = 300
+}
+
+# Root TXT records
+resource "cloudflare_dns_record" "txt_google_verification" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "@"
+  type    = "TXT"
+  content = "google-site-verification=OVm2WzCdpqDTSv0LiDyGGutXT0I8YIlBwuyRHyMJFfw"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "txt_spf" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "@"
+  type    = "TXT"
+  content = "v=spf1 include:_spf.google.com include:mailgun.org a:tietokilta.fi ~all"
+  ttl     = 300
+}
+
+# DKIM records (Google Workspace)
+resource "cloudflare_dns_record" "txt_dkim_google" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "google._domainkey"
+  type    = "TXT"
+  content = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmKCng0S4J1z5VFiL3lu1LIX9K/9CboGePYheGW3WXH71sBlGDILXyapA+caMb5QmyOG5UzXxr9VyBiwP7TEhVveflf94TN7U1pn7DayMrDgVNy2/DUgljyKIfP6m6IyF+9qg/L19S2K7MWt/GO4odLHsvvsDmyEUMbhd+2D612yzVIKtaHocSLiInfF1+YcRcF7h/4fKRTscyjlhAIEVRV8wrKyEcogOnYbuwoDCmzwQs7P57vS4/BBabyifvgs+c8+NGcqytsCaJ6DvWBStwTMAF+FahdoO8U7jUKCULE81SR1onSt2glMXQyqkXoYpq0xhlzUz3DOKp5DUV9WDJQIDAQAB"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "txt_dkim_default" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "default._domainkey"
+  type    = "TXT"
+  content = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3WW6vxgnjzq3sbjziGnfWT2/6V/9ln0lXE+gUc6ntqdylb1v5knW7KqmWkEglGEn+Fd7urds7yJtNMEj7d1gHB1tB+mhtzc9BpOZPWbYihBeTws4mWSY+xx6mjz/VvhPhHlS/mTalJCoQOgFYu6D27e3+Y4e6xjbwfBIKujaQNoukdu8dsVMmFs5AbIjtdAMBrVfl5n9K730foa1qTNypmXz5JgSbJOpVnyCFbD+q39KCcR8Cz/M6BhKPq+XMJO82LAoSsdWIDAIm+Mt9QWd7anqLU0fCYmDwMg4pdWuUUoDRStL7zlFiCiOpWPAxnZ+wzSX5YPoHmh1q+tS0aC+jwIDAQAB"
+  ttl     = 300
+}
+
+# DMARC
+resource "cloudflare_dns_record" "txt_dmarc" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "_dmarc"
+  type    = "TXT"
+  content = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
+  ttl     = 300
+}
+
+# DMARC report authorization for subdomains that send reports to root
+resource "cloudflare_dns_record" "txt_dmarc_reports" {
+  for_each = var.dmarc_report_domains
+  zone_id  = data.cloudflare_zone.zone.id
+  name     = "${each.key}._report._dmarc"
+  type     = "TXT"
+  content  = "v=DMARC1;"
+  ttl      = 300
+}
+
+# Minecraft game server
+resource "cloudflare_dns_record" "mc_a" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "mc"
+  type    = "A"
+  content = "65.109.127.222"
+  proxied = false
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "mc_srv" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "_minecraft._tcp"
+  type    = "SRV"
+  data = {
+    priority = 0
+    weight   = 5
+    port     = 10015
+    target   = "mc.tietokilta.fi"
+  }
+  ttl = 300
+}
+
+# GitHub org challenge
+resource "cloudflare_dns_record" "txt_github_challenge" {
+  zone_id = data.cloudflare_zone.zone.id
+  name    = "_github-challenge-Tietokilta-org"
+  type    = "TXT"
+  content = var.github_challenge_value
+  ttl     = 60
+}

--- a/modules/cloudflare/main.tf
+++ b/modules/cloudflare/main.tf
@@ -200,7 +200,8 @@ resource "cloudflare_dns_record" "mc_srv" {
     port     = 10015
     target   = "mc.tietokilta.fi"
   }
-  ttl = 300
+  ttl      = 300
+  priority = 0
 }
 
 # GitHub org challenge

--- a/modules/cloudflare/outputs.tf
+++ b/modules/cloudflare/outputs.tf
@@ -1,0 +1,4 @@
+output "zone_id" {
+  description = "The Cloudflare zone ID for tietokilta.fi"
+  value       = data.cloudflare_zone.zone.id
+}

--- a/modules/cloudflare/variables.tf
+++ b/modules/cloudflare/variables.tf
@@ -1,0 +1,15 @@
+variable "zone_name" {
+  type        = string
+  description = "The Cloudflare zone name (domain), e.g. tietokilta.fi"
+}
+
+variable "github_challenge_value" {
+  type        = string
+  description = "The GitHub organization challenge TXT record value"
+  sensitive   = true
+}
+
+variable "dmarc_report_domains" {
+  type        = set(string)
+  description = "Set of FQDNs authorized to receive DMARC reports for the root domain"
+}

--- a/modules/discourse/dns.tf
+++ b/modules/discourse/dns.tf
@@ -63,3 +63,61 @@ resource "azurerm_dns_txt_record" "discourse_dmarc" {
     value = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
   }
 }
+
+# Cloudflare DNS records (created alongside Azure records before NS flip)
+resource "cloudflare_dns_record" "discourse_a" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "A"
+  content = var.discourse_ip
+  proxied = false
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "discourse_mx_mxa" {
+  count    = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "mxa.eu.mailgun.org"
+  priority = 10
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "discourse_mx_mxb" {
+  count    = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "mxb.eu.mailgun.org"
+  priority = 10
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "discourse_spf" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "TXT"
+  content = "v=spf1 include:mailgun.org ~all"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "discourse_dkim" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "${var.dkim_selector}._domainkey.${var.subdomain}"
+  type    = "TXT"
+  content = var.dkim_key
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "discourse_dmarc" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "_dmarc.${var.subdomain}"
+  type    = "TXT"
+  content = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
+  ttl     = 300
+}

--- a/modules/discourse/providers.tf
+++ b/modules/discourse/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/modules/discourse/variables.tf
+++ b/modules/discourse/variables.tf
@@ -21,3 +21,9 @@ variable "dkim_key" {
 variable "discourse_ip" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi."
+  default     = ""
+}

--- a/modules/dns/mailman/main.tf
+++ b/modules/dns/mailman/main.tf
@@ -63,3 +63,61 @@ resource "azurerm_dns_txt_record" "list_dmarc" {
     value = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
   }
 }
+
+# Cloudflare DNS records (created alongside Azure records before NS flip)
+resource "cloudflare_dns_record" "list_a" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "A"
+  content = "130.233.48.30"
+  proxied = false
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "list_mx_tietokilta" {
+  count    = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "tietokilta.fi"
+  priority = 20
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "list_mx_mail_cs_hut" {
+  count    = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "mail.cs.hut.fi"
+  priority = 21
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "list_spf" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "TXT"
+  content = "v=spf1 mx include:mailgun.org ~all"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "list_dkim" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "${var.dkim_selector}._domainkey.${var.subdomain}"
+  type    = "TXT"
+  content = var.dkim_key
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "list_dmarc" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "_dmarc.${var.subdomain}"
+  type    = "TXT"
+  content = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
+  ttl     = 300
+}

--- a/modules/dns/mailman/providers.tf
+++ b/modules/dns/mailman/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/modules/dns/mailman/variables.tf
+++ b/modules/dns/mailman/variables.tf
@@ -17,3 +17,9 @@ variable "dkim_selector" {
 variable "dkim_key" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi."
+  default     = ""
+}

--- a/modules/histotik/dns.tf
+++ b/modules/histotik/dns.tf
@@ -5,3 +5,13 @@ resource "azurerm_dns_cname_record" "histotik_cname_record" {
   ttl                 = 300
   record              = "tietokilta.github.io"
 }
+
+resource "cloudflare_dns_record" "histotik_cname" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "CNAME"
+  content = "tietokilta.github.io"
+  proxied = false
+  ttl     = 300
+}

--- a/modules/histotik/providers.tf
+++ b/modules/histotik/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/modules/histotik/variables.tf
+++ b/modules/histotik/variables.tf
@@ -17,3 +17,9 @@ variable "root_zone_name" {
 variable "subdomain" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi."
+  default     = ""
+}

--- a/modules/ilmo/mailgun.tf
+++ b/modules/ilmo/mailgun.tf
@@ -6,4 +6,5 @@ module "mailgun" {
   dns_resource_group_name = var.dns_resource_group_name
   dns_zone_name           = var.root_zone_name
   create_smtp_credential  = false # ilmo uses Mailgun API, not SMTP
+  cloudflare_zone_id      = var.cloudflare_zone_id
 }

--- a/modules/ilmo/main.tf
+++ b/modules/ilmo/main.tf
@@ -111,4 +111,6 @@ module "app_service_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.ilmo_backend.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-ilmo-cert-${var.environment}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/ilmo/variables.tf
+++ b/modules/ilmo/variables.tf
@@ -76,3 +76,14 @@ variable "extra_frontends" {
   }))
   default = {}
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}

--- a/modules/invoicing/mailgun.tf
+++ b/modules/invoicing/mailgun.tf
@@ -6,4 +6,5 @@ module "mailgun" {
   dns_resource_group_name = var.dns_resource_group_name
   dns_zone_name           = var.root_zone_name
   create_smtp_credential  = false
+  cloudflare_zone_id      = var.cloudflare_zone_id
 }

--- a/modules/invoicing/main.tf
+++ b/modules/invoicing/main.tf
@@ -58,5 +58,7 @@ module "app_service_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.invoice_generator.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-invoice-generator-cert-${terraform.workspace}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }
 

--- a/modules/invoicing/variables.tf
+++ b/modules/invoicing/variables.tf
@@ -30,3 +30,14 @@ variable "root_zone_name" {
 variable "acme_account_key" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}

--- a/modules/isopistekortti/main.tf
+++ b/modules/isopistekortti/main.tf
@@ -71,4 +71,6 @@ module "app_service_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.isopistekortti.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-isopistekortti-cert-${var.environment}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/isopistekortti/variables.tf
+++ b/modules/isopistekortti/variables.tf
@@ -34,6 +34,17 @@ variable "acme_account_key" {
   type = string
 }
 
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}
+
 variable "environment" {
   type = string
 }

--- a/modules/mailgun-domain/main.tf
+++ b/modules/mailgun-domain/main.tf
@@ -6,7 +6,14 @@ terraform {
     azurerm = {
       source = "hashicorp/azurerm"
     }
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
   }
+}
+
+locals {
+  use_cloudflare = var.cloudflare_zone_id != ""
 }
 
 # Mailgun domain
@@ -79,6 +86,54 @@ resource "azurerm_dns_txt_record" "dmarc" {
   record {
     value = "v=DMARC1;p=none;sp=none;rua=mailto:${var.dmarc_email}!10m;ruf=mailto:${var.dmarc_email}!10m"
   }
+}
+
+# Cloudflare DNS records (mirroring Azure records when cloudflare_zone_id is set)
+resource "cloudflare_dns_record" "cf_mx_mxa" {
+  count    = local.use_cloudflare ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "mxa.eu.mailgun.org"
+  priority = 10
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "cf_mx_mxb" {
+  count    = local.use_cloudflare ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "mxb.eu.mailgun.org"
+  priority = 10
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "cf_spf" {
+  count   = local.use_cloudflare && var.create_spf ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "TXT"
+  content = "v=spf1 include:mailgun.org ~all"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "cf_dkim" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = local.dkim_record_name
+  type    = "TXT"
+  content = local.dkim_record.value
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "cf_dmarc" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "_dmarc.${var.subdomain}"
+  type    = "TXT"
+  content = "v=DMARC1;p=none;sp=none;rua=mailto:${var.dmarc_email}!10m;ruf=mailto:${var.dmarc_email}!10m"
+  ttl     = 300
 }
 
 # Optional SMTP credential

--- a/modules/mailgun-domain/variables.tf
+++ b/modules/mailgun-domain/variables.tf
@@ -40,3 +40,9 @@ variable "create_spf" {
   type        = bool
   default     = true
 }
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID. When set, DNS records are also created in Cloudflare."
+  type        = string
+  default     = ""
+}

--- a/modules/oldweb/main.tf
+++ b/modules/oldweb/main.tf
@@ -105,4 +105,6 @@ module "oldweb_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.oldweb_backend.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-oldweb-cert-${terraform.workspace}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/oldweb/variables.tf
+++ b/modules/oldweb/variables.tf
@@ -42,6 +42,17 @@ variable "acme_account_key" {
   type = string
 }
 
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}
+
 variable "ghcr_token" {
   type      = string
   sensitive = true

--- a/modules/recruiting/ghost/dns.tf
+++ b/modules/recruiting/ghost/dns.tf
@@ -24,3 +24,32 @@ resource "azurerm_dns_cname_record" "tikjob_cname_email" {
   ttl                 = 300
   record              = "eu.mailgun.org"
 }
+
+# Cloudflare DNS records (when cloudflare_zone_id is set)
+resource "cloudflare_dns_record" "tikjob_txt_google_verification" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "TXT"
+  content = "google-site-verification=CQLRUnnxEnLtINJtF6cyJJH3YQSA8dxD6ap3qmFma5M"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "tikjob_spf" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "TXT"
+  content = "v=spf1 include:mailgun.org ~all"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "tikjob_cname_email" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "email.${var.subdomain}"
+  type    = "CNAME"
+  content = "eu.mailgun.org"
+  proxied = false
+  ttl     = 300
+}

--- a/modules/recruiting/ghost/mailgun.tf
+++ b/modules/recruiting/ghost/mailgun.tf
@@ -7,4 +7,5 @@ module "mailgun" {
   dns_zone_name           = var.root_zone_name
   create_smtp_credential  = false # Uses existing keyvault credentials
   create_spf              = false # SPF is in combined TXT record with Google site verification
+  cloudflare_zone_id      = var.cloudflare_zone_id
 }

--- a/modules/recruiting/ghost/main.tf
+++ b/modules/recruiting/ghost/main.tf
@@ -74,4 +74,6 @@ module "tikjob_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.tikjob_ghost.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tikjob-cert"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/recruiting/ghost/providers.tf
+++ b/modules/recruiting/ghost/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/modules/recruiting/ghost/variables.tf
+++ b/modules/recruiting/ghost/variables.tf
@@ -72,6 +72,19 @@ variable "subdomain" {
   type = string
 }
 
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID. When set, DNS records are also created in Cloudflare."
+  default     = ""
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+  default     = ""
+}
+
 // App Service Plan
 
 variable "tikweb_app_plan_id" {

--- a/modules/registry/mailgun.tf
+++ b/modules/registry/mailgun.tf
@@ -6,4 +6,5 @@ module "mailgun" {
   dns_resource_group_name = var.dns_resource_group_name
   dns_zone_name           = var.root_zone_name
   create_smtp_credential  = false
+  cloudflare_zone_id      = var.cloudflare_zone_id
 }

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -84,4 +84,6 @@ module "app_service_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.registry.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-registry-cert-${var.environment}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/registry/variables.tf
+++ b/modules/registry/variables.tf
@@ -34,6 +34,17 @@ variable "acme_account_key" {
   type = string
 }
 
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}
+
 variable "environment" {
   type = string
 }

--- a/modules/running-challenge/main.tf
+++ b/modules/running-challenge/main.tf
@@ -66,4 +66,6 @@ module "app_service_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.running_challenge.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-running-challenge-cert"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/running-challenge/variables.tf
+++ b/modules/running-challenge/variables.tf
@@ -34,6 +34,17 @@ variable "acme_account_key" {
   type = string
 }
 
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}
+
 variable "client_id" {
   type      = string
   sensitive = true

--- a/modules/status/main.tf
+++ b/modules/status/main.tf
@@ -60,4 +60,6 @@ module "app_service_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.status_app.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-status-cert-${terraform.workspace}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/status/variables.tf
+++ b/modules/status/variables.tf
@@ -39,3 +39,14 @@ variable "telegram_channel_id" {
   description = "Telegram alert channel id"
   type        = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}

--- a/modules/tikpannu/dns.tf
+++ b/modules/tikpannu/dns.tf
@@ -10,3 +10,13 @@ resource "azurerm_dns_a_record" "tikpannu_a" {
   ttl                 = 300
   records             = [var.tikpannu_ip]
 }
+
+resource "cloudflare_dns_record" "tikpannu_a" {
+  count   = var.cloudflare_zone_id != "" ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "A"
+  content = var.tikpannu_ip
+  proxied = false
+  ttl     = 300
+}

--- a/modules/tikpannu/providers.tf
+++ b/modules/tikpannu/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/modules/tikpannu/variables.tf
+++ b/modules/tikpannu/variables.tf
@@ -13,3 +13,9 @@ variable "subdomain" {
 variable "tikpannu_ip" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi."
+  default     = ""
+}

--- a/modules/vaultwarden/mailgun.tf
+++ b/modules/vaultwarden/mailgun.tf
@@ -6,4 +6,5 @@ module "mailgun" {
   dns_resource_group_name = var.dns_resource_group_name
   dns_zone_name           = var.root_zone_name
   create_smtp_credential  = false # Uses root domain SMTP credentials from keyvault
+  cloudflare_zone_id      = var.cloudflare_zone_id
 }

--- a/modules/vaultwarden/main.tf
+++ b/modules/vaultwarden/main.tf
@@ -83,4 +83,6 @@ module "vaultwarden_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.vaultwarden_app.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tik-vaultwarden-cert-${var.environment}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/vaultwarden/variables.tf
+++ b/modules/vaultwarden/variables.tf
@@ -22,6 +22,18 @@ variable "dns_resource_group_name" {
 variable "acme_account_key" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}
+
 variable "db_host" {
   description = "Hostname or IP address of the existing PostgreSQL database"
   type        = string

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -108,4 +108,7 @@ module "tikweb_hostname" {
   app_service_default_hostname    = azurerm_linux_web_app.web.default_hostname
   acme_account_key                = var.acme_account_key
   certificate_name                = "tikweb-cert-${var.environment}"
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
+  proxied                         = true
 }

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -84,3 +84,14 @@ variable "mailgun_url" {
 variable "environment" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for tietokilta.fi. Used for DNS records and ACME challenge."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Cloudflare API token for ACME DNS challenge."
+  sensitive   = true
+}


### PR DESCRIPTION
Add Cloudflare DNS records alongside existing Azure DNS in service modules with count conditionals so they are only created when cloudflare_zone_id is provided.

Migrate app_service_hostname and mailgun-domain modules to Cloudflare with moved blocks for existing state. Thread cloudflare_zone_id and API token through all modules that manage DNS or ACME challenges.

Followed up by PR #208 which removes nearly all existing references to Azure DNS and migrates to a Cloudflare-only configuration