### PR TITLE
chore: add remaining dns records to cloudflare

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -191,6 +191,28 @@ module "dns_github" {
   challenge_value     = module.keyvault.secrets["github-challenge-value"]
 
 }
+# Cloudflare zone lookups for non-tietokilta.fi domains
+data "cloudflare_zone" "juvusivu" {
+  filter = {
+    name = "juhlavuosi.fi"
+  }
+}
+data "cloudflare_zone" "m0" {
+  filter = {
+    name = "muistinnollaus.fi"
+  }
+}
+data "cloudflare_zone" "staging" {
+  filter = {
+    name = "tietokila.fi"
+  }
+}
+data "cloudflare_zone" "tenttiarkisto" {
+  filter = {
+    name = "tenttiarkisto.fi"
+  }
+}
+
 module "mailman" {
   source = "./modules/dns/mailman"
 
@@ -209,6 +231,7 @@ module "mailing_staging" {
   dns_resource_group_name = module.dns_staging.resource_group_name
   root_zone_name          = module.dns_staging.root_zone_name
   subdomain               = "list"
+  cloudflare_zone_id      = data.cloudflare_zone.staging.id
 
   dkim_selector = "mg"
   dkim_key      = "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDZGR9aFa3+4SaHMkvO44EzQzbmMPEYqryH1tsgBlNErA5Qd/UNtCgQ+vy1uO2SyOGZDoD6xEDVZ8Mqh4JXXX3GVvEgpESjSlj+RkhCLY9JGVJwkgVWTUD65qkLJ9NpADBMQUhzJgxIv+It3zxbFDUOmLv2+Qee7d/MR1Gfgn/wNwIDAQAB"
@@ -374,6 +397,8 @@ module "tenttiarkisto" {
   acme_account_key             = module.common.acme_account_key
   dns_resource_group_name      = module.tenttiarkisto_dns_zone.resource_group_name
   root_zone_name               = module.tenttiarkisto_dns_zone.root_zone_name
+  cloudflare_zone_id           = data.cloudflare_zone.tenttiarkisto.id
+  cloudflare_api_token         = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "voo" {
@@ -615,6 +640,9 @@ module "juvusivu" {
   root_zone_name                       = module.dns_juvusivu.root_zone_name
   m0_dns_resource_group_name           = module.dns_m0.resource_group_name
   m0_dns_zone_name                     = module.dns_m0.root_zone_name
+  cloudflare_zone_id                   = data.cloudflare_zone.juvusivu.id
+  cloudflare_m0_zone_id                = data.cloudflare_zone.m0.id
+  cloudflare_api_token                 = module.keyvault.secrets["cloudflare-api-token"]
 }
 
 module "status" {

--- a/modules/dns/mailing/main.tf
+++ b/modules/dns/mailing/main.tf
@@ -1,5 +1,14 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}
+
 locals {
-  fqdn = "${var.subdomain}.${var.root_zone_name}"
+  fqdn           = "${var.subdomain}.${var.root_zone_name}"
+  use_cloudflare = var.cloudflare_zone_id != ""
 }
 
 # Email click tracking CNAME for Mailgun
@@ -62,4 +71,62 @@ resource "azurerm_dns_txt_record" "list_dmarc" {
   record {
     value = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
   }
+}
+
+# Cloudflare DNS records (mirroring Azure records when cloudflare_zone_id is set)
+resource "cloudflare_dns_record" "list_cname_link" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "link.${var.subdomain}"
+  type    = "CNAME"
+  content = "eu.mailgun.org"
+  proxied = false
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "list_mx_mxa" {
+  count    = local.use_cloudflare ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "mxa.eu.mailgun.org"
+  priority = 10
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "list_mx_mxb" {
+  count    = local.use_cloudflare ? 1 : 0
+  zone_id  = var.cloudflare_zone_id
+  name     = var.subdomain
+  type     = "MX"
+  content  = "mxb.eu.mailgun.org"
+  priority = 10
+  ttl      = 300
+}
+
+resource "cloudflare_dns_record" "list_spf" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = var.subdomain
+  type    = "TXT"
+  content = "v=spf1 include:mailgun.org ~all"
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "list_dkim" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "${var.dkim_selector}._domainkey.${var.subdomain}"
+  type    = "TXT"
+  content = var.dkim_key
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "list_dmarc" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "_dmarc.${var.subdomain}"
+  type    = "TXT"
+  content = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
+  ttl     = 300
 }

--- a/modules/dns/mailing/variables.tf
+++ b/modules/dns/mailing/variables.tf
@@ -17,3 +17,8 @@ variable "dkim_selector" {
 variable "dkim_key" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type    = string
+  default = ""
+}

--- a/modules/juvusivu/main.tf
+++ b/modules/juvusivu/main.tf
@@ -110,6 +110,8 @@ module "juvusivu_hostname" {
   acme_account_key                = var.acme_account_key
   certificate_name                = "juvusivu-cert"
   root_zone_name                  = var.root_zone_name
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }
 
 module "juvusivu_m0_hostname" {
@@ -125,4 +127,6 @@ module "juvusivu_m0_hostname" {
   acme_account_key                = var.acme_account_key
   certificate_name                = "juvu-m0-cert"
   root_zone_name                  = var.m0_dns_zone_name
+  cloudflare_zone_id              = var.cloudflare_m0_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }

--- a/modules/juvusivu/variables.tf
+++ b/modules/juvusivu/variables.tf
@@ -48,3 +48,15 @@ variable "m0_dns_resource_group_name" {
 variable "m0_dns_zone_name" {
   type = string
 }
+
+// Cloudflare
+variable "cloudflare_zone_id" {
+  type = string
+}
+variable "cloudflare_m0_zone_id" {
+  type = string
+}
+variable "cloudflare_api_token" {
+  type      = string
+  sensitive = true
+}

--- a/modules/tenttiarkisto/main.tf
+++ b/modules/tenttiarkisto/main.tf
@@ -105,6 +105,8 @@ module "tenttiarkisto_hostname" {
   acme_account_key                = var.acme_account_key
   certificate_name                = "tenttiarkisto-cert"
   root_zone_name                  = var.root_zone_name
+  cloudflare_zone_id              = var.cloudflare_zone_id
+  cloudflare_api_token            = var.cloudflare_api_token
 }
 
 

--- a/modules/tenttiarkisto/variables.tf
+++ b/modules/tenttiarkisto/variables.tf
@@ -47,3 +47,12 @@ variable "dns_resource_group_name" {
 variable "root_zone_name" {
   type = string
 }
+
+variable "cloudflare_zone_id" {
+  type = string
+}
+
+variable "cloudflare_api_token" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
Adds DNS records and enables zones that were not yet added in PR #207. After this is applied and all records have been moved to Cloudflare, PR #208 should be applied to completely remove Azure DNS.