### PR TITLE
feat: stage backups to a dir in storagebox

### DIFF
--- a/tikpannu-nixos-config/modules/backup/azure/postgresql.nix
+++ b/tikpannu-nixos-config/modules/backup/azure/postgresql.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.tik-backup;
   subdir = "azure-psql";
-  user = "azure-psql";
+  user = "backup";
 
   stagingScript = pkgs.writeShellApplication {
     name = "stage-azure-psql-backup";
@@ -84,14 +84,6 @@ in
         User = user;
         Group = user;
       };
-    };
-
-    users = {
-      users.${user} = {
-        isSystemUser = true;
-        group = user;
-      };
-      groups.${user} = { };
     };
   };
 }

--- a/tikpannu-nixos-config/modules/backup/azure/storage.nix
+++ b/tikpannu-nixos-config/modules/backup/azure/storage.nix
@@ -6,7 +6,7 @@
 }:
 let
   cfg = config.services.tik-backup;
-  user = "azure-storage";
+  user = "backup";
   blobSubdir = "azure-blob-storage";
   fileSubdir = "azure-file-storage";
   stagingScript = pkgs.writeShellApplication {
@@ -93,13 +93,6 @@ in
           clean = false;
         }
       ];
-    };
-    users = {
-      users.${user} = {
-        isSystemUser = true;
-        group = user;
-      };
-      groups.${user} = { };
     };
   };
 }

--- a/tikpannu-nixos-config/modules/backup/configuration.nix
+++ b/tikpannu-nixos-config/modules/backup/configuration.nix
@@ -4,7 +4,8 @@
     azure.enable = true;
     storageboxServer = "u563055.your-storagebox.de";
     storageboxMountPath = "/mnt/backup";
-    stagingDir = "/var/lib/backup";
+    resticRepo = "/mnt/backup/restic-repo";
+    stagingDir = "/mnt/backup/staging_dir";
 
     dates = [
       "04:00 Europe/Helsinki"

--- a/tikpannu-nixos-config/modules/backup/default.nix
+++ b/tikpannu-nixos-config/modules/backup/default.nix
@@ -70,6 +70,7 @@ in
         {
           subdir = "discourse";
           user = "discourse";
+          clean = true;
         }
       ];
     };
@@ -78,9 +79,9 @@ in
   config = lib.mkIf cfg.enable {
     systemd.tmpfiles.rules = (
       [
-        ''d "${cfg.stagingDir}" 0711 backup backup -''
+        ''d "${cfg.stagingDir}" 0700 backup backup -''
       ]
-      ++ map (def: ''d "${cfg.stagingDir}/${def.subdir}" 2770 ${def.user} backup -'') cfg.stagingSubdirs
+      ++ map (def: ''d "${cfg.stagingDir}/${def.subdir}" 0700 ${def.user} backup -'') cfg.stagingSubdirs
     );
   };
 }

--- a/tikpannu-nixos-config/modules/backup/restic.nix
+++ b/tikpannu-nixos-config/modules/backup/restic.nix
@@ -152,12 +152,9 @@ in
         '';
       }
       {
-        assertion =
-          !(lib.hasPrefix cfg.storageboxMountPath cfg.stagingDir)
-          && !(lib.hasPrefix cfg.stagingDir cfg.storageboxMountPath);
+        assertion = !(lib.hasPrefix cfg.stagingDir cfg.storageboxMountPath);
         message = ''
-          `services.tik-backup.stagingDir` exists inside
-          `services.tik-backup.storageboxMountPath` or vice versa
+          `services.tik-backup.storageboxMountPath` cannot be inside or equal to `services.tik-backup.stagingDir`
         '';
       }
     ];

--- a/tikpannu-nixos-config/modules/discourse/backup.nix
+++ b/tikpannu-nixos-config/modules/discourse/backup.nix
@@ -7,14 +7,15 @@
 let
   enable = config.services.discourse.enable && config.services.tik-backup.enable;
   stagingDir = config.services.tik-backup.stagingDir;
+  tmpDir = "/tmp/discourse-backup-snapshot";
   subdir = "discourse";
 
-  stagingScript = pkgs.writeShellApplication {
-    name = "stage-discourse-backup";
+  stageToTmp = pkgs.writeShellApplication {
+    name = "stage-discourse-backup-1";
+    runtimeInputs = [ pkgs.acl ];
     text = ''
       set -euo pipefail
       discourseData=/var/lib/discourse/backups/default
-      targetDir="${stagingDir}/${subdir}/"
       if [[ ! -d "$discourseData" || ! -O "$discourseData" ]]; then
         echo "$discourseData does not exist or is not owned by the current user" >&2
         exit 1
@@ -46,30 +47,58 @@ let
       fi
 
       echo "Found $newestBackup to be the newest backup, staging..." >&2
-      umask 0002
-      cp "$newestBackup" "$targetDir/"
+
+      rm -rf "${tmpDir}"
+      mkdir -m 700 "${tmpDir}"
+      cp "$newestBackup" "${tmpDir}/"
+      setfacl -Rm u:backup:rwX "${tmpDir}"
+    '';
+  };
+  stagingScript = pkgs.writeShellApplication {
+    name = "stage-discourse-backup-2";
+    text = ''
+      set -euo pipefail
+
+      cp "${tmpDir}"/* "${stagingDir}/${subdir}/"
+      rm -rf "${tmpDir}"/*
     '';
   };
 in
 {
   config = lib.mkIf enable {
     services.tik-backup = {
-      stagingServices = [ "discourse-stage-backup.service" ];
+      stagingServices = [
+        "discourse-stage-backup1.service"
+        "discourse-stage-backup2.service"
+      ];
       stagingSubdirs = [
         {
           inherit subdir;
-          user = "discourse";
+          user = "backup";
         }
       ];
     };
 
-    systemd.services.discourse-stage-backup = {
-      description = "Stage Discourse backup to ${stagingDir}";
-      restartIfChanged = false;
-      serviceConfig = {
-        Type = "oneshot";
-        ExecStart = lib.getExe stagingScript;
-        User = "discourse";
+    systemd.services = {
+      discourse-stage-backup1 = {
+        description = "Move discourse backup to /tmp for backup user";
+        restartIfChanged = false;
+        serviceConfig = {
+          Type = "oneshot";
+          User = "discourse";
+          ExecStart = lib.getExe stageToTmp;
+        };
+      };
+      discourse-stage-backup2 = {
+        description = "Stage Discourse backup to ${stagingDir}";
+        requires = [ "discourse-stage-backup1.service" ];
+        after = [ "discourse-stage-backup1.service" ];
+        restartIfChanged = false;
+        serviceConfig = {
+          Type = "oneshot";
+          User = "backup";
+          ExecStart = lib.getExe stagingScript;
+        };
       };
     };
   };

--- a/tikpannu-nixos-config/tests/backups.nix
+++ b/tikpannu-nixos-config/tests/backups.nix
@@ -1,6 +1,7 @@
 {
   lib,
   pkgs,
+  config,
   ...
 }:
 {
@@ -83,12 +84,12 @@
     '''')
 
     pannu.succeed("systemctl start restic-backups-tik-backup.service")
-    unit_succeeded("discourse-stage-backup.service")
+    unit_succeeded("discourse-stage-backup2.service")
     unit_succeeded("stage-azure-psql.service")
 
 
     # Backup user must be able to clean up this dir
-    pannu.succeed("sudo -u backup sh -c 'rm -rf /var/lib/backup/*'")
+    pannu.succeed("sudo -u backup sh -c 'rm -rf ${config.nodes.pannu.services.tik-backup.stagingDir}/*'")
 
     _, stdout = pannu.execute("restic-tik-backup ls latest")
     print("Backed up files:")


### PR DESCRIPTION
The azure blob and file storage staging adds about 17 GiB of files. When
these are present, the rootfs only has 3 GiB free space. Since the job
is a sync, having them present reduces traffic as well.

Makes the staging dir be inside the storagebox. All staging jobs to it
need to run under the backup user, as you cannot set granular
permissions with the cifs mount.
