### PR TITLE
feat: add ylikellotus dns to cloudflare

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,6 +176,11 @@ data "cloudflare_zone" "tenttiarkisto" {
     name = "tenttiarkisto.fi"
   }
 }
+data "cloudflare_zone" "ylikellotus" {
+  filter = {
+    name = "ylikellotus.fi"
+  }
+}
 
 module "mailman" {
   source = "./modules/dns/mailman"
@@ -621,3 +626,9 @@ module "isopistekortti" {
   cloudflare_zone_id      = module.cloudflare.zone_id
   cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
 }
+
+module "ylikellotus" {
+  source             = "./modules/ylikellotus"
+  cloudflare_zone_id = data.cloudflare_zone.ylikellotus.id
+}
+

--- a/modules/ylikellotus/dns.tf
+++ b/modules/ylikellotus/dns.tf
@@ -1,0 +1,28 @@
+locals {
+  github_pages_ips = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153",
+  ]
+}
+
+resource "cloudflare_dns_record" "apex_a" {
+  for_each = toset(local.github_pages_ips)
+
+  zone_id = var.cloudflare_zone_id
+  name    = "@"
+  type    = "A"
+  content = each.value
+  proxied = false
+  ttl     = 300
+}
+
+resource "cloudflare_dns_record" "www_cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = "www"
+  type    = "CNAME"
+  content = "ylikellotus.fi"
+  proxied = false
+  ttl     = 300
+}

--- a/modules/ylikellotus/providers.tf
+++ b/modules/ylikellotus/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/modules/ylikellotus/variables.tf
+++ b/modules/ylikellotus/variables.tf
@@ -1,0 +1,4 @@
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for ylikellotus.fi."
+}


### PR DESCRIPTION
These records had been added manually to Azure so it was missed in the mass Azure -> Cloudflare DNS migration

When this is merged, both ylikellotus.fi and the resource group dns-prod-rg should be removed from Azure. NS flip was already done and the resource group has been removed from Terraform state.