### PR TITLE
chore: cloudflare migration cleanup

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,12 +76,62 @@ provider "postgresql" {
 
 locals {
   resource_group_location = "northeurope"
-  # Zone name strings -- previously derived from Azure DNS zone modules
-  tietokilta_zone     = "tietokilta.fi"
-  tietokila_zone      = "tietokila.fi"
-  muistinnollaus_zone = "muistinnollaus.fi"
-  juhlavuosi_zone     = "juhlavuosi.fi"
-  tenttiarkisto_zone  = "tenttiarkisto.fi"
+  cloudflare_account_id   = "06aec0668de6760376b202e63643f132"
+}
+
+resource "cloudflare_zone" "tietokilta" {
+  account = { id = local.cloudflare_account_id }
+  name    = "tietokilta.fi"
+}
+
+resource "cloudflare_zone" "tietokila" {
+  account = { id = local.cloudflare_account_id }
+  name    = "tietokila.fi"
+}
+
+resource "cloudflare_zone" "juhlavuosi" {
+  account = { id = local.cloudflare_account_id }
+  name    = "juhlavuosi.fi"
+}
+
+resource "cloudflare_zone" "muistinnollaus" {
+  account = { id = local.cloudflare_account_id }
+  name    = "muistinnollaus.fi"
+}
+
+resource "cloudflare_zone" "tenttiarkisto" {
+  account = { id = local.cloudflare_account_id }
+  name    = "tenttiarkisto.fi"
+}
+
+resource "cloudflare_zone" "ylikellotus" {
+  account = { id = local.cloudflare_account_id }
+  name    = "ylikellotus.fi"
+}
+
+import {
+  to = cloudflare_zone.tietokilta
+  id = "e3193fc9edbb2b28f743a6d7743176f8"
+}
+import {
+  to = cloudflare_zone.tietokila
+  id = "316c40dc8ddd4ae3a4b2252b8ffb09ba"
+}
+import {
+  to = cloudflare_zone.juhlavuosi
+  id = "a37622fcf717d85b1bf99a0d96991376"
+}
+import {
+  to = cloudflare_zone.muistinnollaus
+  id = "0c3095429c5c1bfbdfc7d8478caf70c0"
+}
+import {
+  to = cloudflare_zone.tenttiarkisto
+  id = "508eea4e22d6e6e2c3c78f0536d207a9"
+}
+import {
+  to = cloudflare_zone.ylikellotus
+  id = "aadd380eabe1b2fc33de6e7532c831b7"
 }
 
 module "keyvault" {
@@ -141,7 +191,7 @@ module "keyvault" {
 module "cloudflare" {
   source = "./modules/cloudflare"
 
-  zone_name              = local.tietokilta_zone
+  zone_id                = cloudflare_zone.tietokilta.id
   github_challenge_value = module.keyvault.secrets["github-challenge-value"]
   # Hardcoded to avoid circular dependency with modules that consume cloudflare.zone_id
   dmarc_report_domains = [
@@ -153,33 +203,6 @@ module "cloudflare" {
     "vaalit.tietokilta.fi",
     "rekisteri.tietokilta.fi",
   ]
-}
-
-# Cloudflare zone lookups for domains migrated from Azure DNS
-data "cloudflare_zone" "juvusivu" {
-  filter = {
-    name = "juhlavuosi.fi"
-  }
-}
-data "cloudflare_zone" "m0" {
-  filter = {
-    name = "muistinnollaus.fi"
-  }
-}
-data "cloudflare_zone" "staging" {
-  filter = {
-    name = "tietokila.fi"
-  }
-}
-data "cloudflare_zone" "tenttiarkisto" {
-  filter = {
-    name = "tenttiarkisto.fi"
-  }
-}
-data "cloudflare_zone" "ylikellotus" {
-  filter = {
-    name = "ylikellotus.fi"
-  }
 }
 
 module "mailman" {
@@ -194,7 +217,7 @@ module "mailman" {
 module "mailing_staging" {
   source = "./modules/dns/mailing"
 
-  cloudflare_zone_id = data.cloudflare_zone.staging.id
+  cloudflare_zone_id = cloudflare_zone.tietokila.id
   subdomain          = "list"
 
   dkim_selector = "mg"
@@ -248,7 +271,7 @@ module "web" {
   resource_group_name          = module.common.resource_group_name
   app_service_plan_id          = module.common.tikweb_app_plan_id
   acme_account_key             = module.common.acme_account_key
-  root_zone_name               = local.tietokilta_zone
+  root_zone_name               = cloudflare_zone.tietokilta.name
   subdomain                    = "@"
   environment                  = "prod"
   mongo_connection_string      = "${module.mongodb.db_connection_string}/payload?retryWrites=true&w=majority"
@@ -294,7 +317,7 @@ module "ilmo" {
     }
   }
 
-  root_zone_name       = local.tietokilta_zone
+  root_zone_name       = cloudflare_zone.tietokilta.name
   subdomain            = "ilmo"
   acme_account_key     = module.common.acme_account_key
   cloudflare_zone_id   = module.cloudflare.zone_id
@@ -323,7 +346,7 @@ module "histotik" {
   env_name                = "prod"
   resource_group_location = local.resource_group_location
 
-  root_zone_name     = local.tietokilta_zone
+  root_zone_name     = cloudflare_zone.tietokilta.name
   subdomain          = "histotik"
   cloudflare_zone_id = module.cloudflare.zone_id
 }
@@ -340,8 +363,8 @@ module "tenttiarkisto" {
   tikweb_app_plan_rg_name      = module.common.resource_group_name
   django_secret_key            = module.keyvault.secrets["tenttiarkisto-django-secret-key"]
   acme_account_key             = module.common.acme_account_key
-  root_zone_name               = local.tenttiarkisto_zone
-  cloudflare_zone_id           = data.cloudflare_zone.tenttiarkisto.id
+  root_zone_name               = cloudflare_zone.tenttiarkisto.name
+  cloudflare_zone_id           = cloudflare_zone.tenttiarkisto.id
   cloudflare_api_token         = module.keyvault.secrets["cloudflare-api-token"]
 }
 
@@ -382,7 +405,7 @@ module "tikjob_app" {
 
   acme_account_key = module.common.acme_account_key
 
-  root_zone_name       = local.tietokilta_zone
+  root_zone_name       = cloudflare_zone.tietokilta.name
   subdomain            = "rekry"
   cloudflare_zone_id   = module.cloudflare.zone_id
   cloudflare_api_token = module.keyvault.secrets["cloudflare-api-token"]
@@ -405,7 +428,7 @@ module "tikjob_tg_bot" {
 module "discourse" {
   source = "./modules/discourse"
 
-  root_zone_name     = local.tietokilta_zone
+  root_zone_name     = cloudflare_zone.tietokilta.name
   subdomain          = "vaalit"
   discourse_ip       = "46.62.222.17"
   cloudflare_zone_id = module.cloudflare.zone_id
@@ -417,7 +440,7 @@ module "discourse" {
 module "tikpannu" {
   source = "./modules/tikpannu"
 
-  root_zone_name     = local.tietokilta_zone
+  root_zone_name     = cloudflare_zone.tietokilta.name
   subdomain          = "pannu"
   tikpannu_ip        = "46.62.222.17"
   cloudflare_zone_id = module.cloudflare.zone_id
@@ -425,7 +448,7 @@ module "tikpannu" {
 module "invoicing" {
   source = "./modules/invoicing"
 
-  root_zone_name = local.tietokilta_zone
+  root_zone_name = cloudflare_zone.tietokilta.name
   subdomain      = "laskutus"
 
   mailgun_api_key         = module.keyvault.secrets["invoice-mailgun-api-key"]
@@ -445,7 +468,7 @@ module "registry" {
   postgres_server_id      = module.common.postgres_server_id
   postgres_server_fqdn    = module.common.postgres_server_fqdn
   environment             = "prod"
-  root_zone_name          = local.tietokilta_zone
+  root_zone_name          = cloudflare_zone.tietokilta.name
   subdomain               = "rekisteri"
   acme_account_key        = module.common.acme_account_key
   mailgun_api_key         = module.keyvault.secrets["registry-mailgun-api-key"]
@@ -460,7 +483,7 @@ module "oldweb" {
   environment          = "prod"
   postgres_server_fqdn = module.common.postgres_server_fqdn
   postgres_server_id   = module.common.postgres_server_id
-  root_zone_name       = local.tietokilta_zone
+  root_zone_name       = cloudflare_zone.tietokilta.name
   subdomain            = "old"
   acme_account_key     = module.common.acme_account_key
   tikweb_app_plan_id   = module.common.tikweb_app_plan_id
@@ -489,7 +512,7 @@ module "vaultwarden" {
   vaultwarden_smtp_username            = module.keyvault.secrets["vaultwarden-smtp-username"]
   vaultwarden_smtp_password            = module.keyvault.secrets["vaultwarden-smtp-password"]
   acme_account_key                     = module.common.acme_account_key
-  root_zone_name                       = local.tietokilta_zone
+  root_zone_name                       = cloudflare_zone.tietokilta.name
   subdomain                            = "vault"
   cloudflare_zone_id                   = module.cloudflare.zone_id
   cloudflare_api_token                 = module.keyvault.secrets["cloudflare-api-token"]
@@ -572,10 +595,10 @@ module "juvusivu" {
   postgres_server_fqdn                 = module.common.postgres_server_fqdn
   postgres_server_id                   = module.common.postgres_server_id
   acme_account_key                     = module.common.acme_account_key
-  root_zone_name                       = local.juhlavuosi_zone
-  m0_dns_zone_name                     = local.muistinnollaus_zone
-  cloudflare_zone_id                   = data.cloudflare_zone.juvusivu.id
-  cloudflare_m0_zone_id                = data.cloudflare_zone.m0.id
+  root_zone_name                       = cloudflare_zone.juhlavuosi.name
+  m0_dns_zone_name                     = cloudflare_zone.muistinnollaus.name
+  cloudflare_zone_id                   = cloudflare_zone.juhlavuosi.id
+  cloudflare_m0_zone_id                = cloudflare_zone.muistinnollaus.id
   cloudflare_api_token                 = module.keyvault.secrets["cloudflare-api-token"]
 }
 
@@ -586,7 +609,7 @@ module "status" {
   app_service_plan_resource_group_name = module.common.resource_group_name
   location                             = local.resource_group_location
   acme_account_key                     = module.common.acme_account_key
-  root_zone_name                       = local.tietokilta_zone
+  root_zone_name                       = cloudflare_zone.tietokilta.name
   telegram_token                       = module.keyvault.secrets["status-telegram-token"]
   telegram_channel_id                  = "-1003648545192"
   subdomain                            = "status"
@@ -602,7 +625,7 @@ module "running_challenge" {
   postgres_server_id      = module.common.postgres_server_id
   postgres_server_fqdn    = module.common.postgres_server_fqdn
   subdomain               = "liikuntahaaste"
-  root_zone_name          = local.tietokilta_zone
+  root_zone_name          = cloudflare_zone.tietokilta.name
   acme_account_key        = module.common.acme_account_key
   client_id               = module.keyvault.secrets["running-challenge-client-id"]
   client_secret           = module.keyvault.secrets["running-challenge-client-secret"]
@@ -621,7 +644,7 @@ module "isopistekortti" {
   postgres_server_fqdn    = module.common.postgres_server_fqdn
   subdomain               = "iso"
   environment             = "prod"
-  root_zone_name          = local.tietokilta_zone
+  root_zone_name          = cloudflare_zone.tietokilta.name
   acme_account_key        = module.common.acme_account_key
   cloudflare_zone_id      = module.cloudflare.zone_id
   cloudflare_api_token    = module.keyvault.secrets["cloudflare-api-token"]
@@ -629,6 +652,6 @@ module "isopistekortti" {
 
 module "ylikellotus" {
   source             = "./modules/ylikellotus"
-  cloudflare_zone_id = data.cloudflare_zone.ylikellotus.id
+  cloudflare_zone_id = cloudflare_zone.ylikellotus.id
 }
 

--- a/modules/app_service_hostname/main.tf
+++ b/modules/app_service_hostname/main.tf
@@ -56,16 +56,6 @@ resource "cloudflare_dns_record" "www_asuid_record" {
   ttl     = 300
 }
 
-# State migrations from count-indexed to non-count resources
-moved {
-  from = cloudflare_dns_record.app_a_record[0]
-  to   = cloudflare_dns_record.app_a_record
-}
-moved {
-  from = cloudflare_dns_record.app_asuid_record[0]
-  to   = cloudflare_dns_record.app_asuid_record
-}
-
 resource "azurerm_app_service_custom_hostname_binding" "app_hostname_binding" {
   hostname            = local.fqdn
   app_service_name    = var.app_service_name

--- a/modules/cloudflare/main.tf
+++ b/modules/cloudflare/main.tf
@@ -6,53 +6,45 @@ terraform {
   }
 }
 
-# Requires the zone to be added to the Cloudflare account manually first,
-# then NS records updated at the registrar to point to Cloudflare.
-data "cloudflare_zone" "zone" {
-  filter = {
-    name = var.zone_name
-  }
-}
-
 resource "cloudflare_zone_setting" "ssl" {
-  zone_id    = data.cloudflare_zone.zone.id
+  zone_id    = var.zone_id
   setting_id = "ssl"
   value      = "strict"
 }
 
 resource "cloudflare_zone_setting" "always_use_https" {
-  zone_id    = data.cloudflare_zone.zone.id
+  zone_id    = var.zone_id
   setting_id = "always_use_https"
   value      = "on"
 }
 
 resource "cloudflare_zone_setting" "min_tls_version" {
-  zone_id    = data.cloudflare_zone.zone.id
+  zone_id    = var.zone_id
   setting_id = "min_tls_version"
   value      = "1.2"
 }
 
 resource "cloudflare_zone_setting" "automatic_https_rewrites" {
-  zone_id    = data.cloudflare_zone.zone.id
+  zone_id    = var.zone_id
   setting_id = "automatic_https_rewrites"
   value      = "on"
 }
 
 resource "cloudflare_zone_setting" "opportunistic_encryption" {
-  zone_id    = data.cloudflare_zone.zone.id
+  zone_id    = var.zone_id
   setting_id = "opportunistic_encryption"
   value      = "on"
 }
 
 resource "cloudflare_zone_setting" "http3" {
-  zone_id    = data.cloudflare_zone.zone.id
+  zone_id    = var.zone_id
   setting_id = "http3"
   value      = "on"
 }
 
 # Cache Next.js static assets for one year (filenames include content hashes)
 resource "cloudflare_ruleset" "cache_rules" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "tikweb cache rules"
   kind    = "zone"
   phase   = "http_request_cache_settings"
@@ -82,7 +74,7 @@ resource "cloudflare_ruleset" "cache_rules" {
 
 # Root domain MX records (Google Workspace)
 resource "cloudflare_dns_record" "mx_aspmx" {
-  zone_id  = data.cloudflare_zone.zone.id
+  zone_id  = var.zone_id
   name     = "@"
   type     = "MX"
   content  = "aspmx.l.google.com"
@@ -91,7 +83,7 @@ resource "cloudflare_dns_record" "mx_aspmx" {
 }
 
 resource "cloudflare_dns_record" "mx_alt1_aspmx" {
-  zone_id  = data.cloudflare_zone.zone.id
+  zone_id  = var.zone_id
   name     = "@"
   type     = "MX"
   content  = "alt1.aspmx.l.google.com"
@@ -100,7 +92,7 @@ resource "cloudflare_dns_record" "mx_alt1_aspmx" {
 }
 
 resource "cloudflare_dns_record" "mx_alt3_aspmx" {
-  zone_id  = data.cloudflare_zone.zone.id
+  zone_id  = var.zone_id
   name     = "@"
   type     = "MX"
   content  = "alt3.aspmx.l.google.com"
@@ -109,7 +101,7 @@ resource "cloudflare_dns_record" "mx_alt3_aspmx" {
 }
 
 resource "cloudflare_dns_record" "mx_tietokilta" {
-  zone_id  = data.cloudflare_zone.zone.id
+  zone_id  = var.zone_id
   name     = "@"
   type     = "MX"
   content  = "tietokilta.fi"
@@ -118,7 +110,7 @@ resource "cloudflare_dns_record" "mx_tietokilta" {
 }
 
 resource "cloudflare_dns_record" "mx_mail_cs_hut" {
-  zone_id  = data.cloudflare_zone.zone.id
+  zone_id  = var.zone_id
   name     = "@"
   type     = "MX"
   content  = "mail.cs.hut.fi"
@@ -128,7 +120,7 @@ resource "cloudflare_dns_record" "mx_mail_cs_hut" {
 
 # Root TXT records
 resource "cloudflare_dns_record" "txt_google_verification" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "@"
   type    = "TXT"
   content = "google-site-verification=OVm2WzCdpqDTSv0LiDyGGutXT0I8YIlBwuyRHyMJFfw"
@@ -136,7 +128,7 @@ resource "cloudflare_dns_record" "txt_google_verification" {
 }
 
 resource "cloudflare_dns_record" "txt_spf" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "@"
   type    = "TXT"
   content = "v=spf1 include:_spf.google.com include:mailgun.org a:tietokilta.fi ~all"
@@ -145,7 +137,7 @@ resource "cloudflare_dns_record" "txt_spf" {
 
 # DKIM records (Google Workspace)
 resource "cloudflare_dns_record" "txt_dkim_google" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "google._domainkey"
   type    = "TXT"
   content = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmKCng0S4J1z5VFiL3lu1LIX9K/9CboGePYheGW3WXH71sBlGDILXyapA+caMb5QmyOG5UzXxr9VyBiwP7TEhVveflf94TN7U1pn7DayMrDgVNy2/DUgljyKIfP6m6IyF+9qg/L19S2K7MWt/GO4odLHsvvsDmyEUMbhd+2D612yzVIKtaHocSLiInfF1+YcRcF7h/4fKRTscyjlhAIEVRV8wrKyEcogOnYbuwoDCmzwQs7P57vS4/BBabyifvgs+c8+NGcqytsCaJ6DvWBStwTMAF+FahdoO8U7jUKCULE81SR1onSt2glMXQyqkXoYpq0xhlzUz3DOKp5DUV9WDJQIDAQAB"
@@ -153,7 +145,7 @@ resource "cloudflare_dns_record" "txt_dkim_google" {
 }
 
 resource "cloudflare_dns_record" "txt_dkim_default" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "default._domainkey"
   type    = "TXT"
   content = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3WW6vxgnjzq3sbjziGnfWT2/6V/9ln0lXE+gUc6ntqdylb1v5knW7KqmWkEglGEn+Fd7urds7yJtNMEj7d1gHB1tB+mhtzc9BpOZPWbYihBeTws4mWSY+xx6mjz/VvhPhHlS/mTalJCoQOgFYu6D27e3+Y4e6xjbwfBIKujaQNoukdu8dsVMmFs5AbIjtdAMBrVfl5n9K730foa1qTNypmXz5JgSbJOpVnyCFbD+q39KCcR8Cz/M6BhKPq+XMJO82LAoSsdWIDAIm+Mt9QWd7anqLU0fCYmDwMg4pdWuUUoDRStL7zlFiCiOpWPAxnZ+wzSX5YPoHmh1q+tS0aC+jwIDAQAB"
@@ -162,7 +154,7 @@ resource "cloudflare_dns_record" "txt_dkim_default" {
 
 # DMARC
 resource "cloudflare_dns_record" "txt_dmarc" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "_dmarc"
   type    = "TXT"
   content = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
@@ -172,7 +164,7 @@ resource "cloudflare_dns_record" "txt_dmarc" {
 # DMARC report authorization for subdomains that send reports to root
 resource "cloudflare_dns_record" "txt_dmarc_reports" {
   for_each = var.dmarc_report_domains
-  zone_id  = data.cloudflare_zone.zone.id
+  zone_id  = var.zone_id
   name     = "${each.key}._report._dmarc"
   type     = "TXT"
   content  = "v=DMARC1;"
@@ -181,7 +173,7 @@ resource "cloudflare_dns_record" "txt_dmarc_reports" {
 
 # Minecraft game server
 resource "cloudflare_dns_record" "mc_a" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "mc"
   type    = "A"
   content = "65.109.127.222"
@@ -190,7 +182,7 @@ resource "cloudflare_dns_record" "mc_a" {
 }
 
 resource "cloudflare_dns_record" "mc_srv" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "_minecraft._tcp"
   type    = "SRV"
   data = {
@@ -205,7 +197,7 @@ resource "cloudflare_dns_record" "mc_srv" {
 
 # GitHub org challenge
 resource "cloudflare_dns_record" "txt_github_challenge" {
-  zone_id = data.cloudflare_zone.zone.id
+  zone_id = var.zone_id
   name    = "_github-challenge-tietokilta-org"
   type    = "TXT"
   content = var.github_challenge_value

--- a/modules/cloudflare/outputs.tf
+++ b/modules/cloudflare/outputs.tf
@@ -1,4 +1,4 @@
 output "zone_id" {
   description = "The Cloudflare zone ID for tietokilta.fi"
-  value       = data.cloudflare_zone.zone.id
+  value       = var.zone_id
 }

--- a/modules/cloudflare/variables.tf
+++ b/modules/cloudflare/variables.tf
@@ -1,6 +1,6 @@
-variable "zone_name" {
+variable "zone_id" {
   type        = string
-  description = "The Cloudflare zone name (domain), e.g. tietokilta.fi"
+  description = "The Cloudflare zone ID for tietokilta.fi"
 }
 
 variable "github_challenge_value" {

--- a/modules/discourse/dns.tf
+++ b/modules/discourse/dns.tf
@@ -48,29 +48,3 @@ resource "cloudflare_dns_record" "discourse_dmarc" {
   content = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
   ttl     = 300
 }
-
-# State migrations from count-indexed to non-count resources
-moved {
-  from = cloudflare_dns_record.discourse_a[0]
-  to   = cloudflare_dns_record.discourse_a
-}
-moved {
-  from = cloudflare_dns_record.discourse_mx_mxa[0]
-  to   = cloudflare_dns_record.discourse_mx_mxa
-}
-moved {
-  from = cloudflare_dns_record.discourse_mx_mxb[0]
-  to   = cloudflare_dns_record.discourse_mx_mxb
-}
-moved {
-  from = cloudflare_dns_record.discourse_spf[0]
-  to   = cloudflare_dns_record.discourse_spf
-}
-moved {
-  from = cloudflare_dns_record.discourse_dkim[0]
-  to   = cloudflare_dns_record.discourse_dkim
-}
-moved {
-  from = cloudflare_dns_record.discourse_dmarc[0]
-  to   = cloudflare_dns_record.discourse_dmarc
-}

--- a/modules/dns/mailman/main.tf
+++ b/modules/dns/mailman/main.tf
@@ -48,29 +48,3 @@ resource "cloudflare_dns_record" "list_dmarc" {
   content = "v=DMARC1;p=none;sp=none;rua=mailto:dmarc@tietokilta.fi!10m;ruf=mailto:dmarc@tietokilta.fi!10m"
   ttl     = 300
 }
-
-# State migrations from count-indexed to non-count resources
-moved {
-  from = cloudflare_dns_record.list_a[0]
-  to   = cloudflare_dns_record.list_a
-}
-moved {
-  from = cloudflare_dns_record.list_mx_tietokilta[0]
-  to   = cloudflare_dns_record.list_mx_tietokilta
-}
-moved {
-  from = cloudflare_dns_record.list_mx_mail_cs_hut[0]
-  to   = cloudflare_dns_record.list_mx_mail_cs_hut
-}
-moved {
-  from = cloudflare_dns_record.list_spf[0]
-  to   = cloudflare_dns_record.list_spf
-}
-moved {
-  from = cloudflare_dns_record.list_dkim[0]
-  to   = cloudflare_dns_record.list_dkim
-}
-moved {
-  from = cloudflare_dns_record.list_dmarc[0]
-  to   = cloudflare_dns_record.list_dmarc
-}

--- a/modules/histotik/dns.tf
+++ b/modules/histotik/dns.tf
@@ -6,8 +6,3 @@ resource "cloudflare_dns_record" "histotik_cname" {
   proxied = false
   ttl     = 300
 }
-
-moved {
-  from = cloudflare_dns_record.histotik_cname[0]
-  to   = cloudflare_dns_record.histotik_cname
-}

--- a/modules/mailgun-domain/main.tf
+++ b/modules/mailgun-domain/main.tf
@@ -70,24 +70,6 @@ resource "cloudflare_dns_record" "cf_dmarc" {
   ttl     = 300
 }
 
-# State migrations from count-indexed to non-count resources
-moved {
-  from = cloudflare_dns_record.cf_mx_mxa[0]
-  to   = cloudflare_dns_record.cf_mx_mxa
-}
-moved {
-  from = cloudflare_dns_record.cf_mx_mxb[0]
-  to   = cloudflare_dns_record.cf_mx_mxb
-}
-moved {
-  from = cloudflare_dns_record.cf_dkim[0]
-  to   = cloudflare_dns_record.cf_dkim
-}
-moved {
-  from = cloudflare_dns_record.cf_dmarc[0]
-  to   = cloudflare_dns_record.cf_dmarc
-}
-
 # Optional SMTP credential
 resource "random_password" "smtp" {
   count   = var.create_smtp_credential ? 1 : 0

--- a/modules/recruiting/ghost/dns.tf
+++ b/modules/recruiting/ghost/dns.tf
@@ -22,17 +22,3 @@ resource "cloudflare_dns_record" "tikjob_cname_email" {
   proxied = false
   ttl     = 300
 }
-
-# State migrations from count-indexed to non-count resources
-moved {
-  from = cloudflare_dns_record.tikjob_txt_google_verification[0]
-  to   = cloudflare_dns_record.tikjob_txt_google_verification
-}
-moved {
-  from = cloudflare_dns_record.tikjob_spf[0]
-  to   = cloudflare_dns_record.tikjob_spf
-}
-moved {
-  from = cloudflare_dns_record.tikjob_cname_email[0]
-  to   = cloudflare_dns_record.tikjob_cname_email
-}

--- a/modules/tikpannu/dns.tf
+++ b/modules/tikpannu/dns.tf
@@ -6,8 +6,3 @@ resource "cloudflare_dns_record" "tikpannu_a" {
   proxied = false
   ttl     = 300
 }
-
-moved {
-  from = cloudflare_dns_record.tikpannu_a[0]
-  to   = cloudflare_dns_record.tikpannu_a
-}


### PR DESCRIPTION
All Cloudflare domains are now managed by Terraform instead of using `data` lookups. Also cleans up a bunch of `moved {}` blocks