### PR TITLE
chore: bump ghost version

### DIFF
--- a/modules/recruiting/ghost/main.tf
+++ b/modules/recruiting/ghost/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_linux_web_app" "tikjob_ghost" {
 
     application_stack {
       docker_registry_url = "https://docker.io"
-      docker_image_name   = "ghost:5.109-alpine"
+      docker_image_name   = "ghost:6.45.0-alpine"
     }
   }
 


### PR DESCRIPTION
Should remove IP restrictions to Ghost and update any remaining secrets that haven't been applied yet. All API keys have been rotated via Ghost and (staff) users forced to recreate their passwords on next login.

The version bump and some secrets have already been applied.