### PR TITLE
feat: pre-stage registry SMTP configuration

### DIFF
--- a/modules/registry/mailgun.tf
+++ b/modules/registry/mailgun.tf
@@ -4,6 +4,7 @@ module "mailgun" {
   domain_name            = "${var.subdomain}.${var.root_zone_name}"
   subdomain              = var.subdomain
   dns_zone_name          = var.root_zone_name
-  create_smtp_credential = false
+  create_smtp_credential = true
+  smtp_login             = "rekisteri-app"
   cloudflare_zone_id     = var.cloudflare_zone_id
 }

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -56,6 +56,12 @@ resource "azurerm_linux_web_app" "registry" {
     MAILGUN_DOMAIN  = module.mailgun.domain
     MAILGUN_URL     = module.mailgun.api_url
 
+    SMTP_HOST = module.mailgun.smtp_host
+    SMTP_PORT = tostring(module.mailgun.smtp_port)
+    SMTP_USER = module.mailgun.smtp_login
+    SMTP_PASS = module.mailgun.smtp_password
+    SMTP_FROM = "TiK-rekisteri <${module.mailgun.mail_from}>"
+
     STRIPE_API_KEY        = var.stripe_api_key
     STRIPE_WEBHOOK_SECRET = var.stripe_webhook_secret
 


### PR DESCRIPTION
## What changed

- create a dedicated `rekisteri-app` Mailgun SMTP credential
- inject `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and `SMTP_FROM` into the registry web app
- retain the existing `MAILGUN_*` settings for application-image rollback compatibility

## Why

This is rollout step 1 for Tietokilta/rekisteri#197, which migrates the application from Mailgun's HTTP API to provider-neutral SMTP.

## Rollout order

1. Merge and apply this PR first. The currently deployed application ignores the new SMTP settings and continues using `MAILGUN_*`.
2. Merge and deploy the application PR.
3. Verify `/api/health`, send a real OTP, and confirm delivery in Mailgun.
4. Only after successful verification, merge the stacked legacy-cleanup PR.

## Rollback

Before the cleanup PR is applied, redeploying the previous application image remains safe because all `MAILGUN_*` settings are retained.