### PR TITLE
chore: remove legacy registry Mailgun config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,6 @@ module "keyvault" {
     "vaultwarden-smtp-password",
     "status-telegram-token",
     "status-telegram-channel-id",
-    "registry-mailgun-api-key",
     "registry-stripe-api-key",
     "registry-stripe-webhook-secret",
     "mailgun-terraform-api-key",
@@ -478,7 +477,6 @@ module "registry" {
   root_zone_name          = cloudflare_zone.tietokilta.name
   subdomain               = "rekisteri"
   acme_account_key        = module.common.acme_account_key
-  mailgun_api_key         = module.keyvault.secrets["registry-mailgun-api-key"]
   stripe_api_key          = module.keyvault.secrets["registry-stripe-api-key"]
   stripe_webhook_secret   = module.keyvault.secrets["registry-stripe-webhook-secret"]
   cloudflare_zone_id      = module.cloudflare.zone_id
@@ -678,4 +676,3 @@ module "kurssikone" {
   sisu_course_api_key     = module.keyvault.secrets["kurssikone-sisu-api-key"]
   admin_secret            = module.keyvault.secrets["kurssikone-admin-secret"]
 }
-

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -51,11 +51,6 @@ resource "azurerm_linux_web_app" "registry" {
     ADDRESS_HEADER = "X-Client-IP" # See: https://github.com/Azure/app-service-linux-docs/blob/master/Things_You_Should_Know/headers.md
     PUBLIC_URL     = "https://${module.app_service_hostname.fqdn}"
 
-    MAILGUN_SENDER  = "TiK-rekisteri <${module.mailgun.mail_from}>"
-    MAILGUN_API_KEY = var.mailgun_api_key
-    MAILGUN_DOMAIN  = module.mailgun.domain
-    MAILGUN_URL     = module.mailgun.api_url
-
     SMTP_HOST = module.mailgun.smtp_host
     SMTP_PORT = tostring(module.mailgun.smtp_port)
     SMTP_USER = module.mailgun.smtp_login

--- a/modules/registry/variables.tf
+++ b/modules/registry/variables.tf
@@ -46,11 +46,6 @@ variable "environment" {
   type = string
 }
 
-variable "mailgun_api_key" {
-  type      = string
-  sensitive = true
-}
-
 variable "stripe_api_key" {
   type      = string
   sensitive = true


### PR DESCRIPTION
## What changed

- remove the registry application's legacy `MAILGUN_*` settings
- remove the now-unused registry Mailgun API-key module input
- stop reading `registry-mailgun-api-key` from Key Vault

The Mailgun domain and its new SMTP credential remain managed by Terraform.

## Stack

- Depends on infra PR #222
- Application migration: Tietokilta/rekisteri#197

This PR intentionally targets `agent/registry-smtp-config` so its diff contains only the legacy cleanup.

## Rollout gate

Do not merge or apply this PR until:

1. infra PR #222 has been merged and applied
2. application PR Tietokilta/rekisteri#197 has been deployed
3. `/api/health` reports the SMTP connection as healthy
4. a real OTP has been received and confirmed in Mailgun events

Keeping this PR separate preserves rollback to the old Mailgun-HTTP application image during verification.
